### PR TITLE
Add notice about required gem of test command

### DIFF
--- a/commands/run-tests.yml
+++ b/commands/run-tests.yml
@@ -1,4 +1,4 @@
-description: "Test with RSpec."
+description: "Test with RSpec. You have to add `gem 'rspec_junit_formatter'` to your Gemfile."
     steps:
       - run: |
           mkdir /tmp/test-results


### PR DESCRIPTION
Without `rspec_junit_formatter` gem, test command fails with the following error message:

```
bundler: failed to load command: rspec (/home/circleci/project/vendor/bundle/ruby/2.6.0/bin/rspec)
LoadError: cannot load such file -- rspec_junit_formatter
```

ref. https://app.circleci.com/jobs/github/vzvu3k6k/Spoon-Knife/6/parallel-runs/0/steps/0-106