### PR TITLE
Better restore_cache keys

### DIFF
--- a/commands/load-cache.yml
+++ b/commands/load-cache.yml
@@ -8,3 +8,4 @@ description: "Load cached RubyGems."
       - restore_cache:
           keys:
             - << parameters.key >>-{{ checksum "Gemfile.lock"  }}
+            - << parameters.key >>-


### PR DESCRIPTION
## Description

If `Gemfile.lock` is updated, the orb command can't restore cache because cache key will also be changed.

This relaxes the cache key and make it restorable even though `Gemfile.lock` is updated.

## Reference

- [Language Guide: Ruby - CircleCI](https://circleci.com/docs/2.0/language-ruby/#sample-configuration)