### PR TITLE
Fix flaky gpg install.

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -19,7 +19,8 @@ steps:
       command: |
         # Fix for retrieving GPG over IPv6 issue
         mkdir ~/.gnupg && echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
-        gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+        curl -sSL https://rvm.io/mpapis.asc | gpg --import -
+        curl -sSL https://rvm.io/pkuczynski.asc | gpg --import -
 
         curl -sSL "https://get.rvm.io" | bash -s stable
         adduser $(whoami) rvm


### PR DESCRIPTION
How we were installing the GPG key was flaky. Aprrox 40% of the time it was failing to receive the key. Switching to fetching the key via curl.