### PR TITLE
Fix --path deprecation warning when running bundle install

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -1,3 +1,8 @@
 description: "Install gems with Bundler."
+parameters:
+  path:
+    description: "Installation path."
+    default: vendor/bundle
+    type: string
 steps:
-  - run: bundle install --path vendor/bundle
+  - run: BUNDLE_PATH=<< parameters.path >>  bundle install


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Ruby Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues
Fixes issue #17 
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
- Added a new parameter `path` with default value of `vendor/bundle`
- Replaced command:
  `bundle install --path vendor/bundle`
with:
  `BUNDLE_PATH=<< parameters.path >> bundle install`
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
