### PR TITLE
Add support for Bundler 2.1.4

### DIFF
--- a/src/commands/install-bundler.yml
+++ b/src/commands/install-bundler.yml
@@ -1,0 +1,7 @@
+description: "Install Bundler."
+parameters:
+  version:
+    description: "Bundler version."
+    type: string
+steps:
+  - run: gem install bundler --version << parameters.version >>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -1,8 +1,3 @@
 description: "Install gems with Bundler."
-parameters:
-  path:
-    description: "Installation path."
-    default: vendor/bundle
-    type: string
 steps:
-  - run: BUNDLE_PATH=<< parameters.path >>  bundle install
+  - run: bundle install

--- a/src/commands/save-cache.yml
+++ b/src/commands/save-cache.yml
@@ -4,8 +4,12 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "gems-v1"
+  path:
+    description: "Gems installation path."
+    type: string
+    default: vendor/bundle
 steps:
   - save_cache:
       key: << parameters.key >>-{{ checksum "Gemfile.lock"  }}
       paths:
-        - vendor/bundle
+        - << parameters.path >>

--- a/src/commands/setup-bundler.yml
+++ b/src/commands/setup-bundler.yml
@@ -1,0 +1,8 @@
+description: "Bundler configuration."
+parameters:
+  path:
+    description: "Gems installation path."
+    type: string
+    default: vendor/bundle
+steps:
+  - run: bundle config set path << parameters.path >>


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Ruby Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
  - _Do we have examples anywhere?_
- [x] README has been updated, if necessary

### Motivation, issues
Fixes #19 and #20 🎉
<!---
	why is this change required? what problem does it solve?
  paste links to any relevant GitHub issues filed against
  this repository that this pull request addresses
-->

### Description
- Add task `install-bundler` to install a specific Bundler version
- Add task `setup-bundler` to allow configure Bundler with path
- Add support for `path` parameter in task `save-cache`
- Replace command:
     `BUNDLE_PATH=<< parameters.path >> bundle install`
      with:
      `bundle install`
      ☝️ This makes running `setup-bundler` before **mandatory**!

⚠️ I'm not sure what's the right way to test if the orb works though.
<!---
  Describe your changes in detail, preferably in an imperative mood,
  i.e., "add `commandA` to `jobB`"
 -->
