### PR TITLE
Remove Apt package no longer needed.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
     steps:
       - run: git clone https://github.com/CircleCI-Public/circleci-demo-ruby-rails.git .
       - run: pwd && ls
-      - run: sudo apt-get update && sudo apt-get install libpq-dev -y
       - ruby/install-deps:
           bundler-version: 1.17.3
           path: ~/project


### PR DESCRIPTION
`libpq-dev` is now pre-installed.