### PR TITLE
Fallback to cache-key Without Branch if Missing

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -23,6 +23,7 @@ steps:
         - restore_cache:
             keys:
               - << parameters.key >>-{{ checksum "<< parameters.path >>/Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "<< parameters.path >>/Gemfile.lock"  }}
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |


### PR DESCRIPTION
This uses a cache-key for the initial build on branches until a cache key is generated specific to the branch.

### Motivation
Builds on new branches always install bundled dependencies without cache. This can be avoided since it is likely a cached version for the exact lockfile already exists.

## Describe
Introducing a fallback key based solely on the lockfile.

Fixes #33.