### PR TITLE
[Bugfix] Cache only bundle instead of the project and install gems in vendor/bundle [semver:patch]

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -13,8 +13,10 @@ parameters:
     default: "."
     type: string
   bundler-version:
-    description: Configure which version of bundler to install and utilize.
-    default: 2.1.4
+    description: >
+      Configure which version of bundler to install and utilize.
+      By default, it gets the bundler version from Gemfile.lock, but if it is not working use this to override.
+    default: ""
     type: string
 steps:
   - when:
@@ -27,11 +29,23 @@ steps:
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |
-        if ! echo $(bundle version)  | grep -q <<parameters.bundler-version>>; then
-          echo "Installing bundler <<parameters.bundler-version>>"
-          gem install bundler:<<parameters.bundler-version>>
+        APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+        if [ -z "$APP_BUNDLER_VERSION" ]; then
+          echo "Could not find bundler version from Gemfile.lock. Please use bundler-version parameter"
         else
-          echo "bundler <<parameters.bundler-version>> is already installed."
+          echo "Gemfile.lock is bundled with bundler version $APP_BUNDLER_VERSION"
+        fi
+
+        if ![ -z <<parameters.bundler-version>> ]; then
+          echo "Found bundler-version parameter to override"
+          APP_BUNDLER_VERSION=<<parameters.bundler-version>>
+        fi
+
+        if ! echo $(bundle version)  | grep -q $APP_BUNDLER_VERSION; then
+          echo "Installing bundler $APP_BUNDLER_VERSION"
+          gem install bundler:$APP_BUNDLER_VERSION
+        else
+          echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
         bundle install
   - when:

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -9,8 +9,10 @@ parameters:
     type: string
     default: "gems-v1"
   path:
-    description: "Installation path."
-    default: "."
+    description: >
+      Installation path.
+      By default, it will run bundle with `--deployment` flag and installs gems to the vendor/bundle directory.
+    default: "./vendor/bundle"
     type: string
   bundler-version:
     description: >
@@ -24,8 +26,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - << parameters.key >>-{{ checksum "<< parameters.path >>/Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "<< parameters.path >>/Gemfile.lock"  }}
+              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |
@@ -47,11 +49,16 @@ steps:
         else
           echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
-        bundle install --deployment
+
+        if "<< parameters.path >>" == "./vendor/bundle"; then
+          bundle install --deployment
+        else
+          bundle install --path=<< parameters.path >>
+        fi
   - when:
       condition: <<parameters.with-cache>>
       steps:
         - save_cache:
-            key: << parameters.key >>-{{ checksum "<< parameters.path >>/Gemfile.lock"  }}-{{ .Branch }}
+            key: << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
             paths:
               - << parameters.path >>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -51,9 +51,9 @@ steps:
         fi
 
         if "<< parameters.path >>" == "./vendor/bundle"; then
-          bundle install --deployment
+          bundle check <<parameters.path>> || bundle install --deployment
         else
-          bundle install --path=<< parameters.path >>
+          bundle check <<parameters.path>> || bundle install --path=<< parameters.path >>
         fi
   - when:
       condition: <<parameters.with-cache>>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -47,7 +47,7 @@ steps:
         else
           echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
-        bundle install
+        bundle install --deployment
   - when:
       condition: <<parameters.with-cache>>
       steps:


### PR DESCRIPTION
Copy of https://github.com/CircleCI-Public/ruby-orb/pull/29
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

fixes https://github.com/CircleCI-Public/ruby-orb/issues/25, https://github.com/CircleCI-Public/ruby-orb/issues/19

### Description

Cache only bundle and save bundle in vendor/bundle so that it can
properly gets cached and not cause problems.

There were several cache related bugs in ruby orb.
- Caching whole project instead of bundle
- Installed gems not being cached because it was being installed in $GEM_PATH

And added some small but nice to have things
- ~~cache fallback~~ Fixed in https://github.com/CircleCI-Public/ruby-orb/pull/28
- detect bundler version from Gemfile.lock
- bundle check before bundle install
