### PR TITLE
[Bugfix] use --path flag for bundle check [semver:patch]

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -51,9 +51,9 @@ steps:
         fi
 
         if "<< parameters.path >>" == "./vendor/bundle"; then
-          bundle check <<parameters.path>> || bundle install --deployment
+          bundle check --path <<parameters.path>> || bundle install --deployment
         else
-          bundle check <<parameters.path>> || bundle install --path=<< parameters.path >>
+          bundle check --path <<parameters.path>> || bundle install --path=<< parameters.path >>
         fi
   - when:
       condition: <<parameters.with-cache>>


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Accidentally removed `--path` flag when rebasing and squashing https://github.com/CircleCI-Public/ruby-orb/pull/36

### Description

It was running bundle check without `--path`, while it should be `bundle check --path install_path`.