### PR TITLE
Update install-deps.yml

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -38,7 +38,7 @@ steps:
           echo "Gemfile.lock is bundled with bundler version $APP_BUNDLER_VERSION"
         fi
 
-        if ![ -z <<parameters.bundler-version>> ]; then
+        if ! [ -z <<parameters.bundler-version>> ]; then
           echo "Found bundler-version parameter to override"
           APP_BUNDLER_VERSION=<<parameters.bundler-version>>
         fi


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Ruby Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

Currently, on bundler install, the script outputs

```
/bin/bash: line 7: ![: command not found
```

which effectively ignores the bundler-version parameter as `command not found` would result in always non-zero exit code.

I believe you need to have space between exclamation mark and the command to treat it as the negation operator against the command, in bash.

### Description

This PR puts whitespace between exclamation mark and `[`