### PR TITLE
Use IPV4 keyserver over IPV6 [semver:patch]

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -13,7 +13,7 @@ steps:
         echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
 
         count=0
-        until gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+        until gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
         do
             count=$((count+1)); sleep 10;
             if [ $count -gt 2 ]; then


### PR DESCRIPTION
GPG key import command failed before rvm install could run. This issue provided some insight into the problem.

https://github.com/rvm/rvm/issues/4215

Moving to IPV4 keyserver fixes things

### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

#39 

### Description

Unsure what is going on but apparently there is some kind of dead IP and DNS issue. I am not very networking savvy but forcing use of the ipv4 GPG keyserver fixes things