### PR TITLE
[semver:patch] chore: Don't check the lock file if not exists.

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -31,11 +31,13 @@ steps:
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |
-        APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
-        if [ -z "$APP_BUNDLER_VERSION" ]; then
-          echo "Could not find bundler version from Gemfile.lock. Please use bundler-version parameter"
-        else
-          echo "Gemfile.lock is bundled with bundler version $APP_BUNDLER_VERSION"
+        if test -f "Gemfile.lock"; then
+          APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+          if [ -z "$APP_BUNDLER_VERSION" ]; then
+            echo "Could not find bundler version from Gemfile.lock. Please use bundler-version parameter"
+          else
+            echo "Gemfile.lock is bundled with bundler version $APP_BUNDLER_VERSION"
+          fi
         fi
 
         if ! [ -z <<parameters.bundler-version>> ]; then


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

The Gemfile.lock in some repo may be absent. For [example](https://github.com/kjvarga/sitemap_generator), at that time if we need to specify the bundler version by `bundler-version` attribute. While we specify this attribute, the script still check the Gemfile.lock，that will cause the CI broken. I must to touch an empty `Gemfile.lock` for avoiding this problem. just like:

```
- run:
          name: Touch a fake Gemfile.lock for passing the test
          command: |
            touch Gemfile.lock
      - ruby/install-deps:
          bundler-version: 2.1.0
          with-cache: false
```

### Description

So, I think it doesn't need to check the `Gemfile.lock` file if not nonexistent for avoiding the CI broken.