### PR TITLE
 feat: Add rubocop command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ruby Orb
 [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/ruby-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/ruby-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/ruby)](https://circleci.com/orbs/registry/orb/circleci/ruby) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/CircleCI-Public/ruby-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-Easily cache and install your Ruby Gems automatically, run parallel RSpec tests, or just install Ruby.
+Easily cache and install your Ruby Gems automatically, run parallel RSpec tests or Rubocop checking, or just install Ruby.
 
 
 ## Usage

--- a/src/commands/rubocop-check.yml
+++ b/src/commands/rubocop-check.yml
@@ -1,0 +1,16 @@
+description: "Check the code by Rubocop. You have to add `gem 'rubocop'` to your Gemfile. Enable parallelism on CircleCI for faster checking."
+parameters:
+  format:
+    description: "Customize the formatter for rubocop https://docs.rubocop.org/rubocop/0.88/formatters.html"
+    default: "progress"
+    type: string
+
+  out-path:
+    description: "Customize the directory of output file"
+    default: "/tmp/rubocop-results"
+    type: string
+
+steps:
+  - run: |
+      mkdir -p <<parameters.out-path>>
+      bundle exec rubocop --out <<parameters.out-path>>/check-results.xml --format <<parameters.format>>

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -17,6 +17,15 @@ usage:
         - node/install-packages:
             pkg-manager: yarn
             cache-key: "yarn.lock"
+    checking:
+      docker:
+        - image: cimg/ruby:2.7-node
+      steps:
+        - checkout
+        - ruby/install-deps
+        - ruby/rubocop-check:
+            format: progress
+
     test:
       parallelism: 3 # OPTIONAL: Split and run your tests in parallel
       docker:
@@ -51,6 +60,7 @@ usage:
     build_and_test:
       jobs:
         - build
+        - checking
         - test:
             requires:
               - build


### PR DESCRIPTION
### Checklist

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

There are too many project protect their code quality by integrating Rubocop, It might be a good chance to add associate command in this ORB.  #43 

### Description

We can simply enable Rubocop's checking by `ruby/rubocop-check` directive. Otherwise we can customize behavior by `format` and `out-path` parameters.
