### PR TITLE
[semver:skip] Revert dev orb version in CI config.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ parameters:
     default: false
   dev-orb-version:
     type: string
-    default: "dev:int-testing"
+    default: "dev:alpha"
 
 jobs:
   integration-tests:


### PR DESCRIPTION
`int-testing` -> `alpha`