### PR TITLE
Let branches have priority over lockfile for cache

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -58,9 +58,9 @@ steps:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |
         if "<< parameters.path >>" == "./vendor/bundle"; then
-          bundle check --path <<parameters.path>> || bundle install --deployment
+          bundle check --path <<parameters.path>> || (bundle install --deployment && bundle clean)
         else
-          bundle check --path <<parameters.path>> || bundle install --path=<< parameters.path >>
+          bundle check --path <<parameters.path>> || (bundle install --path=<< parameters.path >> && bundle clean)
         fi
   - when:
       condition: <<parameters.with-cache>>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -52,8 +52,9 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
+              - << parameters.key >>-{{ .Branch }}-{{ checksum "./Gemfile.lock"  }}
+              - << parameters.key >>-{{ .Branch }}
+              - << parameters.key >>-
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
       command: |
@@ -66,6 +67,6 @@ steps:
       condition: <<parameters.with-cache>>
       steps:
         - save_cache:
-            key: << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
+            key: << parameters.key >>-{{ .Branch }}-{{ checksum "./Gemfile.lock"  }}
             paths:
               - << parameters.path >>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -21,15 +21,8 @@ parameters:
     default: ""
     type: string
 steps:
-  - when:
-      condition: <<parameters.with-cache>>
-      steps:
-        - restore_cache:
-            keys:
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
   - run:
-      name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
+      name: 'Check Gemfile.lock'
       command: |
         if test -f "Gemfile.lock"; then
           APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
@@ -45,13 +38,25 @@ steps:
           APP_BUNDLER_VERSION=<<parameters.bundler-version>>
         fi
 
-        if ! echo $(bundle version)  | grep -q $APP_BUNDLER_VERSION; then
+        if ! echo $(bundle version) | grep -q $APP_BUNDLER_VERSION; then
           echo "Installing bundler $APP_BUNDLER_VERSION"
           gem install bundler:$APP_BUNDLER_VERSION
         else
           echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
 
+        test -f Gemfile.lock || bundle lock
+
+  - when:
+      condition: <<parameters.with-cache>>
+      steps:
+        - restore_cache:
+            keys:
+              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
+  - run:
+      name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
+      command: |
         if "<< parameters.path >>" == "./vendor/bundle"; then
           bundle check --path <<parameters.path>> || bundle install --deployment
         else


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Ruby Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [ ] Examples have been added for any significant new features
- [x] README has been updated, if necessary

### Motivation, issues

By doing so we ensure that new branches can count on the already existing cache from the master branch, 
requiring the installation of only the gems added by the branch. 

The lock-file is way more specific than branches in this regard.

### Description

So the change puts the branch as the baseline for any change in the Gemfile.lock, and the `master` branch as the base for new branches. This makes the hit-rate for the cache much higher and the execution faster.