### PR TITLE
Add task label parameters for RSpec and Rubocop commands [semver:patch]

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -1,14 +1,20 @@
 description: "Test with RSpec. You have to add `gem 'rspec_junit_formatter'` to your Gemfile. Enable parallelism on CircleCI for faster testing."
 parameters:
+    label:
+        default: "RSpec Tests"
+        description: "Task label"
+        type: string
     out-path:
         description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         default: "/tmp/test-results/rspec"
         type: string
 steps:
-    - run: |
-        mkdir -p <<parameters.out-path>>
-        TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
-        bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
+    - run:
+        name: <<parameters.label>>
+        command: |
+            mkdir -p <<parameters.out-path>>
+            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
     - store_test_results:
         path: <<parameters.out-path>>
     - store_artifacts:

--- a/src/commands/rubocop-check.yml
+++ b/src/commands/rubocop-check.yml
@@ -1,5 +1,9 @@
 description: "Check the code by Rubocop. You have to add `gem 'rubocop'` to your Gemfile. Enable parallelism on CircleCI for faster checking."
 parameters:
+  label:
+    default: "Rubocop Checks"
+    description: "Task label"
+    type: string
   format:
     description: "Customize the formatter for rubocop https://docs.rubocop.org/rubocop/0.88/formatters.html"
     default: "progress"
@@ -13,6 +17,8 @@ parameters:
     type: string
 
 steps:
-  - run: |
-      mkdir -p <<parameters.out-path>>
-      bundle exec rubocop <<parameters.check-path>> --out <<parameters.out-path>>/check-results.xml --format <<parameters.format>>
+  - run:
+      name: <<parameters.label>>
+      command: |
+        mkdir -p <<parameters.out-path>>
+        bundle exec rubocop <<parameters.check-path>> --out <<parameters.out-path>>/check-results.xml --format <<parameters.format>>

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -24,6 +24,7 @@ usage:
         - checkout
         - ruby/install-deps
         - ruby/rubocop-check:
+            label: "Inspecting with Rubocop"
             format: progress
 
     test:


### PR DESCRIPTION
### Checklist

<!--
	thank you for contributing to the CircleCI Ruby Orb!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions
- [x] Examples have been added for any significant new features
- [x] README has been updated, if necessary
    - There was nothing to add, but I wanted this box to be checked.

### Motivation, issues

I was setting up CircleCI for myself for the first time and noticed the RSpec and Rubocop commands output a fairly verbose string:

![Screen Shot 2020-08-07 at 10 48 24 AM](https://user-images.githubusercontent.com/1645017/89660245-16138880-d89f-11ea-8d24-3f368ccb045e.png)

I understand that having this information can be useful, but I wanted to change those labels to something more pleasant looking.

### Description

Add `label` parameters to the `ruby/rspec-test` and `ruby/rubocop-check` commands.
