### PR TITLE
[semver:minor] add command to precompile assets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
           command: bundle exec rails db:schema:load --trace
       - ruby/rspec-test
       - ruby/rubocop-check
+      - ruby/assets-precompile
 
   install-on-machine:
     machine:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ruby Orb
 [![CircleCI Build Status](https://circleci.com/gh/CircleCI-Public/ruby-orb.svg?style=shield "CircleCI Build Status")](https://circleci.com/gh/CircleCI-Public/ruby-orb) [![CircleCI Orb Version](https://img.shields.io/badge/endpoint.svg?url=https://badges.circleci.io/orb/circleci/ruby)](https://circleci.com/orbs/registry/orb/circleci/ruby) [![GitHub License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://raw.githubusercontent.com/CircleCI-Public/ruby-orb/master/LICENSE) [![CircleCI Community](https://img.shields.io/badge/community-CircleCI%20Discuss-343434.svg)](https://discuss.circleci.com/c/ecosystem/orbs)
 
-Easily cache and install your Ruby Gems automatically, run parallel RSpec tests or Rubocop checking, or just install Ruby.
+Easily cache and install your Ruby Gems automatically, run parallel RSpec tests, Rubocop checking, Precomiple Assets, or just install Ruby.
 
 
 ## Usage

--- a/src/commands/assets-precompile.yml
+++ b/src/commands/assets-precompile.yml
@@ -1,0 +1,56 @@
+description: "Assets Precompile with Bundler."
+parameters:
+  with-cache:
+    type: boolean
+    default: true
+    description: Enable automatic caching of your asset dependencies for increased speed.
+  key:
+    description: "The cache key to use. The key is immutable."
+    type: string
+    default: "assets-v1"
+  bundler-version:
+    description: >
+      Configure which version of bundler to install and utilize.
+      By default, it gets the bundler version from Gemfile.lock, but if it is not working use this to override.
+    default: ""
+    type: string
+steps:
+  - when:
+      condition: <<parameters.with-cache>>
+      steps:
+        - restore_cache:
+            keys:
+              - << parameters.key >>-{{ checksum "./public/assets"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "./public/assets"  }}
+  - run:
+      name: Assets Precompile <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
+      command: |
+        if test -f "Gemfile.lock"; then
+          APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
+          if [ -z "$APP_BUNDLER_VERSION" ]; then
+            echo "Could not find bundler version from Gemfile.lock. Please use bundler-version parameter"
+          else
+            echo "Gemfile.lock is bundled with bundler version $APP_BUNDLER_VERSION"
+          fi
+        fi
+
+        if ! [ -z <<parameters.bundler-version>> ]; then
+          echo "Found bundler-version parameter to override"
+          APP_BUNDLER_VERSION=<<parameters.bundler-version>>
+        fi
+
+        if ! echo $(bundle version)  | grep -q $APP_BUNDLER_VERSION; then
+          echo "Installing bundler $APP_BUNDLER_VERSION"
+          gem install bundler:$APP_BUNDLER_VERSION
+        else
+          echo "bundler $APP_BUNDLER_VERSION is already installed."
+        fi
+
+        bundle exec rake assets:precompile
+  - when:
+      condition: <<parameters.with-cache>>
+      steps:
+        - save_cache:
+            key: << parameters.key >>-{{ checksum "./public/assets"  }}-{{ .Branch }}
+            paths:
+              - << parameters.path >>

--- a/src/commands/assets-precompile.yml
+++ b/src/commands/assets-precompile.yml
@@ -8,12 +8,6 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "assets-v1"
-  path:
-    description: >
-      Assets Path.
-      By default, it will compile all assets in /public/assets directory.
-    default: "./public/assets"
-    type: string
   bundler-version:
     description: >
       Configure which version of bundler to install and utilize.
@@ -59,5 +53,4 @@ steps:
         - save_cache:
             key: << parameters.key >>-{{ checksum "./public/assets"  }}-{{ .Branch }}
             paths:
-              - tmp/cache/
               - << parameters.path >>

--- a/src/commands/assets-precompile.yml
+++ b/src/commands/assets-precompile.yml
@@ -8,6 +8,12 @@ parameters:
     description: "The cache key to use. The key is immutable."
     type: string
     default: "assets-v1"
+  path:
+    description: >
+      Assets Path.
+      By default, it will compile all assets in /public/assets directory.
+    default: "./public/assets"
+    type: string
   bundler-version:
     description: >
       Configure which version of bundler to install and utilize.
@@ -53,4 +59,5 @@ steps:
         - save_cache:
             key: << parameters.key >>-{{ checksum "./public/assets"  }}-{{ .Branch }}
             paths:
+              - tmp/cache/
               - << parameters.path >>

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -28,7 +28,7 @@ usage:
             format: progress
     assets:
       docker:
-        - images: cimg/ruby:2.7-node
+        - image: cimg/ruby:2.7-node
       steps:
         - checkout
         - ruby/install-deps

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -26,6 +26,13 @@ usage:
         - ruby/rubocop-check:
             label: "Inspecting with Rubocop"
             format: progress
+    assets:
+      docker:
+        - images: cimg/ruby:2.7-node
+      steps:
+        - checkout
+        - ruby/install-deps
+        - ruby/assets-precompile
 
     test:
       parallelism: 3 # OPTIONAL: Split and run your tests in parallel
@@ -65,3 +72,4 @@ usage:
         - test:
             requires:
               - build
+        - assets


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [X] Minor
- [ ] Patch

## Description:

Enables the command: `bundle exec rake assets:precompile` as `- ruby/assets-precompile` and caches the assets for repeated builds.

## Motivation:

This command is very frequently used in coordination with setting up a rails application with this orb.  Currently we have to use two separate orbs to accomplish this.

 **Closes Issues:**
-  None

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [X] All new jobs, commands, executors, parameters have descriptions.
- [X] Usage Example version numbers have been updated.
- [X] Changelog has been updated.