### PR TITLE
Fix bad conditional in bundle install

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -52,7 +52,7 @@ steps:
           echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
 
-        if "<< parameters.path >>" == "./vendor/bundle"; then
+        if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
           bundle check --path <<parameters.path>> || bundle install --deployment
         else
           bundle check --path <<parameters.path>> || bundle install --path=<< parameters.path >>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [ ] Minor
- [X] Patch

## Description:
fix conditional on bundle deps path check

## Motivation:
The conditional in install-deps was not working correctly. 

was

```
Gemfile.lock is bundled with bundler version 2.1.4
bundler 2.1.4 is already installed.
/bin/bash: line 21: ./vendor/bundle: No such file or directory
```

now

```
Gemfile.lock is bundled with bundler version 2.1.4
bundler 2.1.4 is already installed.
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path './vendor/bundle'`, and stop using this flag
The dependency tzinfo-data (>= 0) will be unused by any of the platforms Bundler is installing for. Bundler is installing for ruby but the dependency is only for x86-mingw32, x86-mswin32, x64-mingw32, java. To add those platforms to the bundle, run `bundle lock --add-platform x86-mingw32 x86-mswin32 x64-mingw32 java`.
The Gemfile's dependencies are satisfied
```

