### PR TITLE
Executor: mention cimg/, not circleci/ [semver:skip]

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -3,7 +3,7 @@ description: |
   Any available tag from this list can be used: https://hub.docker.com/r/cimg/ruby/tags
 parameters:
   tag:
-    description: "The `circleci/ruby` Docker image version tag."
+    description: "The `cimg/ruby` Docker image version tag."
     type: string
     default: "2.7"
 docker:


### PR DESCRIPTION
This change makes the description more accurate.