### PR TITLE
[semver:patch] Use non-deprecated 'bundle config' commands

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -53,10 +53,10 @@ steps:
         fi
 
         if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
-          bundle check --path <<parameters.path>> || bundle install --deployment
-        else
-          bundle check --path <<parameters.path>> || bundle install --path=<< parameters.path >>
+          bundle config set path << parameters.path >>
+          bundle config set deployment 'true'
         fi
+        bundle check || bundle install
   - when:
       condition: <<parameters.with-cache>>
       steps:

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -53,9 +53,9 @@ steps:
         fi
 
         if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
-          bundle config set path << parameters.path >>
           bundle config set deployment 'true'
         fi
+        bundle config set path << parameters.path >>
         bundle check || bundle install
   - when:
       condition: <<parameters.with-cache>>


### PR DESCRIPTION
When running this orb in CircleCI, the following deprecation warnings are passed:
```shell
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, 
which bundler will no longer do in future versions. Instead please use `bundle config set path './vendor/bundle'`, 
and stop using this flag
```
And

```shell
Install missing gems with `bundle install`
[DEPRECATED] The `--deployment` flag is deprecated because it relies on being remembered across bundler 
invocations, which bundler will no longer do in future versions. Instead please use `bundle config set deployment 'true'`, 
and stop using this flag
```

This PR updates the calls to use the recommended `bundle config` commands instead