### PR TITLE
Add support for Bundler 1.x and Bundle 2.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
   install-on-machine:
     machine:
-      image: ubuntu-1604:202004-01
+      image: ubuntu-2004:202111-02
     steps:
       - ruby/install:
           version: "2.7.0"

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -59,10 +59,18 @@ steps:
           echo "bundler $APP_BUNDLER_VERSION is already installed."
         fi
 
-        if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
-          bundle config set deployment 'true'
+        if bundle config set > /dev/null 2>&1; then
+          if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
+            bundle config deployment 'true'
+          fi
+          bundle config path << parameters.path >>
+        else
+          if [ "<< parameters.path >>" == "./vendor/bundle" ]; then
+            bundle config set deployment 'true'
+          fi
+          bundle config set path << parameters.path >>
         fi
-        bundle config set path << parameters.path >>
+
         bundle check || bundle install
   - when:
       condition: <<parameters.with-cache>>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -29,11 +29,23 @@ steps:
         fi
 
         curl -sSL "https://get.rvm.io" | bash -s stable
-        # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
-        echo 'export PATH=$PATH:$HOME/.rvm/bin' >> $BASH_ENV
-        echo "source $HOME/.rvm/scripts/rvm" >> $BASH_ENV
-        # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
-        echo "source $HOME/.rvm/scripts/rvm" >> ~/.bashrc
+
+        # check for machine image specific path
+        if [ -d /opt/circleci/.rvm ]; then
+          echo "Setting PATH up for system install"
+          # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
+          echo 'export PATH=$PATH:/opt/circleci/.rvm/bin' >> $BASH_ENV
+          echo "source /opt/circleci/.rvm/scripts/rvm" >> $BASH_ENV
+          # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
+          echo "source /opt/circleci/.rvm/scripts/rvm" >> ~/.bashrc
+        else
+          echo "Setting PATH up for local install"
+          # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set
+          echo 'export PATH=$PATH:$HOME/.rvm/bin' >> $BASH_ENV
+          echo "source $HOME/.rvm/scripts/rvm" >> $BASH_ENV
+          # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
+          echo "source $HOME/.rvm/scripts/rvm" >> ~/.bashrc
+        fi
 
   - run:
       name: "Install Ruby v<< parameters.version >> via RVM"


### PR DESCRIPTION
To fix a deprecation warning about the use of `--path` in May a change
was shipped to use `bundle config set path`. The `bundle config` command
was changed in 2.1 to use `bundle config [set|list|get|unset] <name> <val>`
but before then the format was `bundle config <name> <val>`. Following on
from that then, anyone using this orb with Bundler 1.x or 2.0 will have a
bundle config setting called `set` and the value of it will be
`path <<parameter.path>>`. This simply doesn't work and results in gems
being installed into ~/rubygems outside the project directory and
consequently a completely empty cache during the save step.

Running `bundle config set` without anything else throws an error on
Bundler 2.1 because it expects `name` and `value` to be supplied. On
the older Bundler versions it succeeds and returns the setting for
config variable called `set`. We can use this fact to implement a
Bundler semantics check and issue the `path` and `deployment` settings
correctly for the currently used Bundler binary.