### PR TITLE
[semver:minor] Add parameter app-dir for install-deps

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -12,7 +12,7 @@ parameters:
     description: >
       Installation path.
       By default, it will run bundle with `--deployment` flag and installs gems to the vendor/bundle directory.
-    default: "/vendor/bundle"
+    default: "./vendor/bundle"
     type: string
   bundler-version:
     description: >

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -31,8 +31,8 @@ steps:
       steps:
         - restore_cache:
             keys:
-              - << parameters.key >>-{{ checksum "<< app-dir.key >>/Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "<< app-dir.key >>/Gemfile.lock"  }}
+              - << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}
               - << parameters.key >>
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -12,7 +12,7 @@ parameters:
     description: >
       Installation path.
       By default, it will run bundle with `--deployment` flag and installs gems to the vendor/bundle directory.
-    default: "./vendor/bundle"
+    default: "/vendor/bundle"
     type: string
   bundler-version:
     description: >
@@ -20,17 +20,23 @@ parameters:
       By default, it gets the bundler version from Gemfile.lock, but if it is not working use this to override.
     default: ""
     type: string
+  app-dir:
+    description: >
+      Path to the directory containing your Gemfile file. Not needed if Gemfile lives in the root.
+    default: .
+    type: string
 steps:
   - when:
       condition: <<parameters.with-cache>>
       steps:
         - restore_cache:
             keys:
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
+              - << parameters.key >>-{{ checksum "<< app-dir.key >>/Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "<< app-dir.key >>/Gemfile.lock"  }}
               - << parameters.key >>
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
+      working_directory: <<parameters.app-dir>>
       command: |
         if test -f "Gemfile.lock"; then
           APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
@@ -62,6 +68,6 @@ steps:
       condition: <<parameters.with-cache>>
       steps:
         - save_cache:
-            key: << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
+            key: << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}-{{ .Branch }}
             paths:
-              - << parameters.path >>
+              - <<parameters.app-dir>>/<< parameters.path >>


### PR DESCRIPTION
There is case that we want to use install-deps in not project root directory.
(Install each ios/android directory for Flutter/React Native, etc)

Therefore, I added app-dir parameter.

Idea is as same as this node orb's command parameter
https://circleci.com/developer/orbs/orb/circleci/node#commands-install-packages