### PR TITLE
[semver:minor] Update glob paths for test-splitting to pick up the correct test files

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -20,17 +20,23 @@ parameters:
       By default, it gets the bundler version from Gemfile.lock, but if it is not working use this to override.
     default: ""
     type: string
+  app-dir:
+    description: >
+      Path to the directory containing your Gemfile file. Not needed if Gemfile lives in the root.
+    default: .
+    type: string
 steps:
   - when:
       condition: <<parameters.with-cache>>
       steps:
         - restore_cache:
             keys:
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
-              - << parameters.key >>-{{ checksum "./Gemfile.lock"  }}
+              - << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}-{{ .Branch }}
+              - << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}
               - << parameters.key >>
   - run:
       name: Bundle Install <<^parameters.with-cache>>(No Cache)<</parameters.with-cache>>
+      working_directory: <<parameters.app-dir>>
       command: |
         if test -f "Gemfile.lock"; then
           APP_BUNDLER_VERSION=$(cat Gemfile.lock | tail -1 | tr -d " ")
@@ -62,6 +68,6 @@ steps:
       condition: <<parameters.with-cache>>
       steps:
         - save_cache:
-            key: << parameters.key >>-{{ checksum "./Gemfile.lock"  }}-{{ .Branch }}
+            key: << parameters.key >>-{{ checksum "<<parameters.app-dir>>/Gemfile.lock"  }}-{{ .Branch }}
             paths:
-              - << parameters.path >>
+              - <<parameters.app-dir>>/<< parameters.path >>

--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -1,19 +1,23 @@
 description: "Test with RSpec. You have to add `gem 'rspec_junit_formatter'` to your Gemfile. Enable parallelism on CircleCI for faster testing."
 parameters:
+    test-files-path:
+        default: "**/*_spec.rb"
+        description: Glob to define where your test files are kept within your repository.
+        type: string
     label:
         default: "RSpec Tests"
         description: "Task label"
         type: string
     out-path:
-        description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         default: "/tmp/test-results/rspec"
+        description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         type: string
 steps:
     - run:
         name: <<parameters.label>>
         command: |
             mkdir -p <<parameters.out-path>>
-            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob <<parameters.test-files-path>> | circleci tests split --split-by=timings)
             bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
     - store_test_results:
         path: <<parameters.out-path>>


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
The current test files glob hardcodes the path to: `"spec/**/*_spec.rb"` which causes test splitting to default to splitting tests by name with this error: 
```
Error reading historical timing data: file does not exist
```

I have created a new parameter to allow users of this orb to pass in their own glob paths, and in the event they do not, it will default to: `"**/*_spec.rb"`. 

I have also changed the ordering of the description of the out-path to match the rest of the file.

## Motivation:
 **Closes Issues:**
-  [History not working between runs](https://github.com/CircleCI-Public/ruby-orb/issues/30)
-  [Allow specifying glob for rspec-tests command](https://github.com/CircleCI-Public/ruby-orb/issues/55)

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [ ] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.