### PR TITLE
[semver:minor] Add optional with-clean flag to run post install, update config file for testing and 1 example for reference

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - run: git clone https://github.com/CircleCI-Public/circleci-demo-ruby-rails.git .
       - ruby/install-deps:
           key: "gems-v4"
+          with-clean: true
       - restore_cache:
           keys:
             - rails-demo-yarn-v3-{{ checksum "yarn.lock" }}

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -1,13 +1,19 @@
 description: "Install gems with Bundler."
 parameters:
-  with-cache:
+  with-clean:
+    description: >
+      Run `bundle clean --force` after `bundle install` to clean Bundler before saving dependencies to cache.
+      By default, it is set to false.
+    default: false
     type: boolean
-    default: true
+  with-cache:
     description: Enable automatic caching of your gemfile dependencies for increased speed.
+    default: true
+    type: boolean
   key:
     description: "The cache key to use. The key is immutable."
-    type: string
     default: "gems-v1"
+    type: string
   path:
     description: >
       Installation path.
@@ -63,7 +69,12 @@ steps:
           bundle config set deployment 'true'
         fi
         bundle config set path << parameters.path >>
-        bundle check || bundle install
+
+        if [ "<< parameters.with-clean >>" = true ]; then
+          bundle check || (bundle install && bundle clean --force)
+        else
+          bundle check || bundle install
+        fi
   - when:
       condition: <<parameters.with-cache>>
       steps:

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -12,7 +12,8 @@ usage:
         - image: cimg/ruby:2.7-node
       steps:
         - checkout
-        - ruby/install-deps
+        - ruby/install-deps:
+            with-clean: true
         # Store bundle cache
         - node/install-packages:
             pkg-manager: yarn
@@ -22,7 +23,8 @@ usage:
         - image: cimg/ruby:2.7-node
       steps:
         - checkout
-        - ruby/install-deps
+        - ruby/install-deps:
+            with-clean: true
         - ruby/rubocop-check:
             label: "Inspecting with Rubocop"
             format: progress


### PR DESCRIPTION

**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
Add an optional 'with-clean' flag to install-deps to run `bundle clean --force` after `bundle install` to clean Bundler before saving dependencies to cache. By default, it is set to false unless specifically referenced such as: 

```
...
    steps:
      - ruby/install-deps:
          with-clean: true
...
```

## Motivation:
 **Closes Issues:**
-  [Run bundle clean in install-deps](https://github.com/CircleCI-Public/ruby-orb/issues/81)

## Checklist:
- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [x] Changelog has been updated.