### PR TITLE
[semver:minor] Update glob paths for test-splitting

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -1,19 +1,23 @@
 description: "Test with RSpec. You have to add `gem 'rspec_junit_formatter'` to your Gemfile. Enable parallelism on CircleCI for faster testing."
 parameters:
+    include:
+        default: "spec/**/*_spec.rb"
+        description: Glob to define where your test files are kept within your repository.
+        type: string
     label:
         default: "RSpec Tests"
         description: "Task label"
         type: string
     out-path:
-        description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         default: "/tmp/test-results/rspec"
+        description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         type: string
 steps:
     - run:
         name: <<parameters.label>>
         command: |
             mkdir -p <<parameters.out-path>>
-            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob <<parameters.include>> | circleci tests split --split-by=timings)
             bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
     - store_test_results:
         path: <<parameters.out-path>>

--- a/src/examples/ruby_rails_sample_app.yml
+++ b/src/examples/ruby_rails_sample_app.yml
@@ -56,7 +56,8 @@ usage:
             name: Database setup
             command: bundle exec rails db:schema:load --trace
         # Run rspec in parallel
-        - ruby/rspec-test
+        - ruby/rspec-test:
+            include: "spec/**/*_spec.rb"
   workflows:
     build_and_test:
       jobs:


### PR DESCRIPTION
**SEMVER Update Type:**
- [ ] Major
- [x] Minor
- [ ] Patch

## Description:
The current test files glob hardcodes the path to: `"spec/**/*_spec.rb"` which causes test splitting to default to splitting tests by name if there is no `/spec` in the root of the repository with this error: 
```
Error reading historical timing data: file does not exist
```

I have created a new parameter to allow users of this orb to pass in their own glob paths, and in the event they do not, it will default to the original: `"spec/**/*_spec.rb"`. 

I have also changed the ordering of the description of the out-path to match the rest of the file.

## Motivation:
 **Closes Issues:**
-  [History not working between runs](https://github.com/CircleCI-Public/ruby-orb/issues/30)
-  [Allow specifying glob for rspec-tests command](https://github.com/CircleCI-Public/ruby-orb/issues/55)

## Checklist:

<!--
	Thank you for contributing to CircleCI Orbs!
	before submitting your a request, please go through the following
	items and place an x in the [ ] if they have been completed
-->

- [x] All new jobs, commands, executors, parameters have descriptions.
- [x] Usage Example version numbers have been updated.
- [ ] Changelog has been updated.