### PR TITLE
Make sure to quote the rspec glob so it properly expands

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -17,7 +17,7 @@ steps:
         name: <<parameters.label>>
         command: |
             mkdir -p <<parameters.out-path>>
-            TESTFILES=$(circleci tests glob <<parameters.include>> | circleci tests split --split-by=timings)
+            TESTFILES=$(circleci tests glob "<<parameters.include>>" | circleci tests split --split-by=timings)
             bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
     - store_test_results:
         path: <<parameters.out-path>>


### PR DESCRIPTION
I think this should go here as opposed to the default include, otherwise anyone who overrides things would have to handle the quoting themselves.

Fixes: https://github.com/CircleCI-Public/ruby-orb/issues/86