### PR TITLE
Add app-dir to other commands [semver:minor]

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -12,6 +12,11 @@ parameters:
         default: "/tmp/test-results/rspec"
         description: Where to save the rspec.xml file. Will automatically be saved to test_results and artifacts on CircleCI.
         type: string
+    app-dir:
+        description: >
+            Path to the directory containing your Gemfile file. Not needed if Gemfile lives in the root.
+        default: .
+        type: string
 steps:
     - run:
         name: <<parameters.label>>
@@ -19,6 +24,7 @@ steps:
             mkdir -p <<parameters.out-path>>
             TESTFILES=$(circleci tests glob "<<parameters.include>>" | circleci tests split --split-by=timings)
             bundle exec rspec $TESTFILES --profile 10 --format RspecJunitFormatter --out <<parameters.out-path>>/results.xml --format progress
+        working_directory: <<parameters.app-dir>>
     - store_test_results:
         path: <<parameters.out-path>>
     - store_artifacts:

--- a/src/commands/rubocop-check.yml
+++ b/src/commands/rubocop-check.yml
@@ -15,10 +15,15 @@ parameters:
     description: "Customize the directory of output file"
     default: "/tmp/rubocop-results"
     type: string
-
+  app-dir:
+    description: >
+      Path to the directory containing your Gemfile file. Not needed if Gemfile lives in the root.
+    default: .
+    type: string
 steps:
   - run:
       name: <<parameters.label>>
       command: |
         mkdir -p <<parameters.out-path>>
         bundle exec rubocop <<parameters.check-path>> --out <<parameters.out-path>>/check-results.xml --format <<parameters.format>>
+      working_directory: <<parameters.app-dir>>


### PR DESCRIPTION
The `install-deps` command supports "app-dir" added in https://github.com/CircleCI-Public/ruby-orb/pull/79, but only on that command for some reason.

This adds `app-dir` for other commands, which is needed for working in a monorepo.