### PR TITLE
fix: installs the correct bundler version if the provided version doesn't match

### DIFF
--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -14,7 +14,7 @@ if [ -n "$PARAM_BUNDLER_VERSION" ]; then
   APP_BUNDLER_VERSION="$PARAM_BUNDLER_VERSION"
 fi
 
-if bundle version | grep -q $APP_BUNDLER_VERSION; then
+if ! bundle version | grep -q $APP_BUNDLER_VERSION; then
   echo "Installing bundler $APP_BUNDLER_VERSION"
   gem install bundler:$APP_BUNDLER_VERSION
 else


### PR DESCRIPTION
Update the ```install-deps.sh``` so that it installs the correct bundler version if the version doesn't match. Otherwise, if the version does match, don't do anything, the correct version is already installed. 