### PR TITLE
feat: allow `install` command's version parameter to be evaluated

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -73,7 +73,7 @@ jobs:
   install-on-machine:
     parameters:
       image:
-        description: Enter the version that should be user for the machine executor.
+        description: Enter the version that should be used for the machine executor.
         type: string  
     executor: 
       name: ubuntu
@@ -93,6 +93,19 @@ jobs:
         - run:
             name: "Test Install"
             command: ruby --version | grep "2.6"
+  install-from-env-var:
+      docker:
+        - image: cimg/node:current
+      steps:
+        - run:
+            name: Set RUBY_VERSION env var
+            command: |
+              echo "export RUBY_VERSION='2.7.0'" >> $BASH_ENV
+        - ruby/install:
+            version: "${RUBY_VERSION}"
+        - run:
+            name: "Test Install"
+            command: ruby --version | grep "2.7.0"
 
 workflows:
   test-deploy:
@@ -107,6 +120,8 @@ workflows:
           filters: *filters
       - install-on-node:
           filters: *filters
+      - install-from-env-var:
+          filters: *filters
       - orb-tools/pack:
           filters: *filters
       - orb-tools/publish:
@@ -118,6 +133,7 @@ workflows:
             - integration-tests
             - install-on-machine
             - install-on-node
+            - install-from-env-var
           context: orb-publishing
           filters:
             branches:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -19,7 +19,10 @@ executors:
 jobs:
   integration-tests:
     docker:
-      - image: cimg/ruby:2.7-node
+      # NOTE: the specific Ruby version required is based on https://github.com/CircleCI-Public/circleci-demo-ruby-rails
+      # See https://github.com/CircleCI-Public/circleci-demo-ruby-rails/blob/2033c5f8da3010941127e0f9133925bd8efc7a79/Gemfile#L10
+      # When the project's Ruby version requirement is updated, we will need to update here as well.
+      - image: cimg/ruby:2.7.5-node
       - image: cimg/postgres:14.2
         environment:
           POSTGRES_USER: circleci-demo-ruby

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -1,7 +1,11 @@
 description: "Install Ruby within a build. To be used in a Linux distro with Apt available."
 parameters:
   version:
-    description: "Ruby version."
+    description: >
+      Ruby version.
+      This can be a literal value (e.g, `2.7.5`).
+      You can also pass in a string to be evaluated.
+      For example, `${MY_RUBY_VERSION}` or `$(cat foo/bar/.ruby-version)`.
     type: string
 steps:
   - run:

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-rvm install "$PARAM_VERSION"
-rvm use "$PARAM_VERSION"
+PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
 
-readonly ruby_path="$(rvm $PARAM_VERSION 1> /dev/null 2> /dev/null && rvm env --path)"
+rvm install "$PARAM_RUBY_VERSION"
+rvm use "$PARAM_RUBY_VERSION"
+
+readonly ruby_path="$(rvm $PARAM_RUBY_VERSION 1> /dev/null 2> /dev/null && rvm env --path)"
 printf '%s\n' "source $ruby_path" >> $BASH_ENV


### PR DESCRIPTION
This will allow support of users passing in env vars, like `'${MY_RUBY_VERSION}'` or things like `'$(cat foo/bar/.ruby-version)'`.

I am not sure [if `eval echo` is the safest option](https://unix.stackexchange.com/a/332607), but understand we use `eval echo` for such operations too, like in `aws-ecr/ecr-login` command:
https://github.com/CircleCI-Public/aws-ecr-orb/blob/0c27bfab932b60f1c60a4c2e74bee114f8d4b795/src/scripts/ecr-login.sh#L2

I have a working example of this modified script in this sample project:
https://github.com/kelvintaywl-cci/ruby-orb-explore

config: https://github.com/kelvintaywl-cci/ruby-orb-explore/blob/main/.circleci/config.yml
green build showcase: https://app.circleci.com/pipelines/github/kelvintaywl-cci/ruby-orb-explore/6/workflows/d79f5368-bfa7-4356-a26d-88d353dad25d/jobs/8

I think this can help resolve #76 indirectly too.
