### PR TITLE
feat: Add tag option to run only selected specs

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -25,6 +25,12 @@ parameters:
             Use the order parameter to tell RSpec how to order the files, groups, and examples.
             Available options can be found at: https://relishapp.com/rspec/rspec-core/docs/command-line/order
         type: string
+    tag:
+        default: ""
+        description: >
+            Use the tag parameter to tell RSpec to run only examples with (or without) a specified tag.
+            Available options can be found at: https://relishapp.com/rspec/rspec-core/v/3-11/docs/command-line/tag-option
+        type: string
 steps:
     - run:
         name: <<parameters.label>>
@@ -32,6 +38,7 @@ steps:
             PARAM_OUT_PATH: <<parameters.out-path>>
             PARAM_INCLUDE: <<parameters.include>>
             PARAM_ORDER: <<parameters.order>>
+            PARAM_TAG: <<parameters.tag>>
         command: <<include(scripts/rspec-test.sh)>>
         working_directory: <<parameters.app-dir>>
     - store_test_results:

--- a/src/scripts/rspec-test.sh
+++ b/src/scripts/rspec-test.sh
@@ -31,12 +31,14 @@ while IFS= read -r line; do test_files+=("$line"); done <<< "$split_files"
 # Rollback IFS
 IFS="$old_ifs"
 
+args=()
+
 if [ -n "$PARAM_TAG" ]; then
-  TAG_OPTION="--tag $PARAM_TAG"
+  args+=(--tag "$PARAM_TAG")
 fi
 
 # Parse array of test files to string separated by single space and run tests
 # Leaving set -x here because it's useful for debugging what files are being tested
 set -x
-bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress --order "$PARAM_ORDER" $TAG_OPTION
+bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress --order "$PARAM_ORDER" "${args[@]}"
 set +x

--- a/src/scripts/rspec-test.sh
+++ b/src/scripts/rspec-test.sh
@@ -20,7 +20,7 @@ fi
 readonly old_ifs="$IFS"
 
 # Split globs per comma and run the CLI split command
-IFS="," 
+IFS=","
 read -ra globs <<< "$PARAM_INCLUDE"
 split_files=$(circleci tests glob "${globs[@]}" | circleci tests split --split-by=timings)
 
@@ -31,8 +31,12 @@ while IFS= read -r line; do test_files+=("$line"); done <<< "$split_files"
 # Rollback IFS
 IFS="$old_ifs"
 
+if [ -n "$PARAM_TAG" ]; then
+  TAG_OPTION="--tag $PARAM_TAG"
+fi
+
 # Parse array of test files to string separated by single space and run tests
 # Leaving set -x here because it's useful for debugging what files are being tested
 set -x
-bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress --order "$PARAM_ORDER"
+bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress --order "$PARAM_ORDER" $TAG_OPTION
 set +x


### PR DESCRIPTION
This allows to only run subset of specs by using RSpec tag option.

Details: https://relishapp.com/rspec/rspec-core/v/3-11/docs/command-line/tag-option

Resolves: #108 