### PR TITLE
fix: Shellcheck error and out of date orb publish context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ workflows:
           requires:
             [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           # Use a context to hold your publishing token.
-          context: orb-publishing
+          context: orb-publisher
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,7 +134,7 @@ workflows:
             - install-on-machine
             - install-on-node
             - install-from-env-var
-          context: orb-publishing
+          context: orb-publisher
           filters:
             branches:
               ignore: /.*/

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -5,5 +5,5 @@ PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
 rvm install "$PARAM_RUBY_VERSION"
 rvm use "$PARAM_RUBY_VERSION"
 
-readonly ruby_path="$(rvm $PARAM_RUBY_VERSION 1> /dev/null 2> /dev/null && rvm env --path)"
-printf '%s\n' "source $ruby_path" >> $BASH_ENV
+RUBY_PATH="$(rvm $PARAM_RUBY_VERSION 1> /dev/null 2> /dev/null && rvm env --path)"
+printf '%s\n' "source $RUBY_PATH" >> $BASH_ENV


### PR DESCRIPTION
- Removed extraneous readonly to resolve a shellcheck error (readonly does not matter in context of orb scripts)
- Updated orb publishing context