### PR TITLE
Specify rubocop `out` flag as the last argument

### DIFF
--- a/src/scripts/rubocop-check.sh
+++ b/src/scripts/rubocop-check.sh
@@ -4,11 +4,11 @@ mkdir -p "$PARAM_OUT_PATH"
 
 if [ "$PARAM_PARALLEL" -eq 0 ]; then
   bundle exec rubocop "$PARAM_CHECK_PATH" \
-  --out $"$PARAM_OUT_PATH"/check-results.xml \
-  --format "$PARAM_FORMAT"
+  --format "$PARAM_FORMAT" \
+  --out $"$PARAM_OUT_PATH"/check-results.xml
 else
   bundle exec rubocop "$PARAM_CHECK_PATH" \
-  --out $"$PARAM_OUT_PATH"/check-results.xml \
+  --parallel \
   --format "$PARAM_FORMAT" \
-  --parallel
+  --out $"$PARAM_OUT_PATH"/check-results.xml
 fi


### PR DESCRIPTION
It seems that the `--out` flag of rubocop is ignored unless it is specified as last argument.
Running `rubocop --out out.junit --format junit` will print to STDOUT instead of writing to file.
Tested on `circleci/ruby@2.0.0` and `rubocop:1.45.1`.