### PR TITLE
Make profile parameter optional

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -25,6 +25,11 @@ parameters:
             Use the order parameter to tell RSpec how to order the files, groups, and examples.
             Available options can be found at: https://relishapp.com/rspec/rspec-core/docs/command-line/order
         type: string
+    profile:
+        default: true
+        description: >
+            Use the profile parameter to enable or disable RSpec profiling
+        type: boolean
     tag:
         default: ""
         description: >
@@ -44,6 +49,7 @@ steps:
             PARAM_INCLUDE: <<parameters.include>>
             PARAM_ORDER: <<parameters.order>>
             PARAM_TAG: <<parameters.tag>>
+            PARAM_PROFILE: <<parameters.profile>>
         command: <<include(scripts/rspec-test.sh)>>
         no_output_timeout: <<parameters.no_output_timeout>>
         working_directory: <<parameters.app-dir>>

--- a/src/scripts/rspec-test.sh
+++ b/src/scripts/rspec-test.sh
@@ -41,8 +41,12 @@ if [ -n "$PARAM_TAG" ]; then
   args+=(--tag "$PARAM_TAG")
 fi
 
+if [ "$PARAM_PROFILE" = true ]; then
+  args+=(--profile 10)
+fi
+
 # Parse array of test files to string separated by single space and run tests
 # Leaving set -x here because it's useful for debugging what files are being tested
 set -x
-bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress "${args[@]}"
+bundle exec rspec "${test_files[@]}" --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress "${args[@]}"
 set +x


### PR DESCRIPTION
Adds the `profile` parameter to the `rspec-test` command, so we can disable profiling.