### PR TITLE
ci: migrate orb tools 12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 setup: true
 orbs:
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@12.0
   shellcheck: circleci/shellcheck@3.1
 
 filters: &filters
@@ -18,19 +18,11 @@ workflows:
       - orb-tools/review:
           filters: *filters
       - shellcheck/check:
-          exclude: SC2148,SC2038,SC2086,SC2002,SC2016
-          filters: *filters
-      - orb-tools/publish:
-          orb-name: circleci/ruby
-          vcs-type: << pipeline.project.type >>
-          requires:
-            [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
-          # Use a context to hold your publishing token.
-          context: orb-publisher
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:
-          pipeline-number: << pipeline.number >>
-          vcs-type: << pipeline.project.type >>
-          requires: [orb-tools/publish]
+          orb_name: ruby
+          pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
+          requires: [orb-tools/lint, orb-tools/review, orb-tools/pack, shellcheck/check]
           filters: *filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,10 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
+          exclude: RC010
           filters: *filters
       - shellcheck/check:
+          exclude: SC2086,SC2016,SC2002
           filters: *filters
       # Triggers the next workflow in the Orb Development Kit.
       - orb-tools/continue:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -157,4 +157,4 @@ workflows:
             - install-from-env-var
             - test-openssl-3
           context: orb-publisher
-          filters: filters: *release-filters
+          filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,6 +1,6 @@
 version: 2.1
 orbs:
-  orb-tools: circleci/orb-tools@12
+  orb-tools: circleci/orb-tools@12.0
   ruby: {}
 
 filters: &filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,19 +1,25 @@
 version: 2.1
 orbs:
-  ruby: circleci/ruby@dev:<<pipeline.git.revision>>
-  orb-tools: circleci/orb-tools@11.1
+  orb-tools: circleci/orb-tools@12
+  ruby: {}
 
 filters: &filters
   tags:
     only: /.*/
+
+release-filters: &release-filters
+  branches:
+    ignore: /.*/
+  tags:
+    only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
 
 executors:
   ubuntu:
     parameters:
       image:
         description: Enter the version that should be user for the machine executor.
-        type: string  
-    machine: 
+        type: string
+    machine:
       image: << parameters.image >>
 
 jobs:
@@ -26,7 +32,7 @@ jobs:
           version: 2.7.6
       - ruby/install-deps:
           app-dir: sample
-      - ruby/rspec-test: 
+      - ruby/rspec-test:
           app-dir: sample
   integration-tests:
     docker:
@@ -86,8 +92,8 @@ jobs:
     parameters:
       image:
         description: Enter the version that should be used for the machine executor.
-        type: string  
-    executor: 
+        type: string
+    executor:
       name: ubuntu
       image: << parameters.image >>
     steps:
@@ -136,11 +142,13 @@ workflows:
       - install-from-env-var:
           filters: *filters
       - orb-tools/pack:
-          filters: *filters
+          filters: *release-filters
       - orb-tools/publish:
-          orb-name: circleci/ruby
-          vcs-type: << pipeline.project.type >>
-          pub-type: production
+          orb_name: circleci/ruby
+          vcs_type: << pipeline.project.type >>
+          pub_type: production
+          enable_pr_comment: true
+          github_token: GHI_TOKEN
           requires:
             - orb-tools/pack
             - integration-tests
@@ -149,8 +157,4 @@ workflows:
             - install-from-env-var
             - test-openssl-3
           context: orb-publisher
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/
+          filters: filters: *release-filters


### PR DESCRIPTION
## Changes

This PR migrates the Ruby orb to Orb Tools 12.