### PR TITLE
ci: add missing filter in `test-openssl-3`

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -136,7 +136,8 @@ workflows:
             parameters:
               image: [ubuntu-2004:202111-02]
           filters: *filters
-      - test-openssl-3
+      - test-openssl-3:
+          filters: *filters
       - install-on-node:
           filters: *filters
       - install-from-env-var:


### PR DESCRIPTION
## Changes

Add filter in `test-openssl-3` job. Otherwise, it won't run for releases. 