### PR TITLE
[semver:minor] Add support for rerun failed tests only

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -39,7 +39,7 @@ parameters:
     rerun-fail:
         default: true
         description: >
-            Enabling the option uses circleci tests run command and allows the "Rerun failed tests only" feature. 
+            Enabling the option uses circleci tests run command and allows the "Rerun failed tests only" feature.
             This feature helps optimize test execution by re-running only the failed tests from previous test run data.
             More information can be found at: https://circleci.com/docs/rerun-failed-tests-only
         type: boolean

--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -36,6 +36,13 @@ parameters:
         description: >
             Allows you to specify the no_output_timeout for the rspec test. Defaults to 10m.
         default: "10m"
+    rerun-fail:
+        default: false
+        description: >
+            Enabling the option uses circleci tests run command and allows the "Rerun failed tests only" feature. 
+            This feature helps optimize test execution by re-running only the failed tests from previous test run data.
+            More information can be found at: https://circleci.com/docs/rerun-failed-tests-only
+        type: boolean
 steps:
     - run:
         name: <<parameters.label>>
@@ -44,6 +51,7 @@ steps:
             PARAM_INCLUDE: <<parameters.include>>
             PARAM_ORDER: <<parameters.order>>
             PARAM_TAG: <<parameters.tag>>
+            PARAM_RERUN_FAIL: <<parameters.rerun-fail>>
         command: <<include(scripts/rspec-test.sh)>>
         no_output_timeout: <<parameters.no_output_timeout>>
         working_directory: <<parameters.app-dir>>

--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -37,7 +37,7 @@ parameters:
             Allows you to specify the no_output_timeout for the rspec test. Defaults to 10m.
         default: "10m"
     rerun-fail:
-        default: false
+        default: true
         description: >
             Enabling the option uses circleci tests run command and allows the "Rerun failed tests only" feature. 
             This feature helps optimize test execution by re-running only the failed tests from previous test run data.

--- a/src/scripts/rspec-test.sh
+++ b/src/scripts/rspec-test.sh
@@ -48,7 +48,7 @@ fi
 # Parse array of test files to string separated by single space and run tests
 # Leaving set -x here because it's useful for debugging what files are being tested
 set -x
-  if [[ "$PARAM_RERUN_FAIL" == "true" ]]; then
+  if [ "$PARAM_RERUN_FAIL" = 1 ]; then
     circleci tests glob "${globs[@]}" | circleci tests run --command "xargs bundle exec rspec --profile 10 --format RspecJunitFormatter --out \"$PARAM_OUT_PATH\"/results.xml --format progress ${args[*]}" --verbose --split-by=timings
   else
     prepare_split_files


### PR DESCRIPTION
🎫 close: #128 

## Changes 

Added `rerun-fail` option so that user can use `circleci tests run` for rspec which is a required prerequisite command for rerun failed tests. 

## Background

Ruby orb already supports uploading to the test results so adding the `circleci test run` enables the feature to be usable.

> Your testing job in the workflow is configured to [upload test results](https://circleci.com/docs/collect-test-data/) to CircleCI. file or classname attributes must be present in the [JUnit XML output](https://circleci.com/docs/use-the-circleci-cli-to-split-tests/#junit-xml-reports).
> 
> The testing job uses circleci tests run (see below for details) to execute tests.
> https://circleci.com/docs/rerun-failed-tests-only/#prerequisites

## Confirm

Confirmed that `ruby/rspec-test` can rerun failed test

Pipeline that I confirmed with: https://app.circleci.com/pipelines/github/nanophate-cci/ruby-orb/7

<img width="1079" alt="Screenshot 2023-07-12 at 2 36 59" src="https://github.com/CircleCI-Public/ruby-orb/assets/6015450/716ff90c-a5c9-449e-8e6d-b823b445f9e8">

https://app.circleci.com/pipelines/github/nanophate-cci/ruby-orb/7/workflows/91e397d8-57a3-4f69-b074-0f9b91af1cb3/jobs/7?invite=true#step-110-52

<img width="1074" alt="Screenshot 2023-07-12 at 2 38 45" src="https://github.com/CircleCI-Public/ruby-orb/assets/6015450/1a8b1f14-3097-4070-9544-644ed9246486">

https://app.circleci.com/pipelines/github/nanophate-cci/ruby-orb/7/workflows/91e397d8-57a3-4f69-b074-0f9b91af1cb3/jobs/7/parallel-runs/1?filterBy=ALL&invite=true#step-110-60
