### PR TITLE
Update links in rspec-test.yml

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -23,13 +23,13 @@ parameters:
         default: ""
         description: >
             Use the order parameter to tell RSpec how to order the files, groups, and examples.
-            Available options can be found at: https://relishapp.com/rspec/rspec-core/docs/command-line/order
+            Available options can be found at: https://rspec.info/features/3-12/rspec-core/command-line/order
         type: string
     tag:
         default: ""
         description: >
             Use the tag parameter to tell RSpec to run only examples with (or without) a specified tag.
-            Available options can be found at: https://relishapp.com/rspec/rspec-core/v/3-11/docs/command-line/tag-option
+            Available options can be found at: https://rspec.info/features/3-12/rspec-core/command-line/tag
         type: string
     no_output_timeout:
         type: string


### PR DESCRIPTION
Background:
In this pull request, I've updated the links in repository related to the Gherkin Examples. 
Previously, Gherkin examples could be read on [RelishApp](http://relishapp.com/rspec) but currently this service is unavailable. 
Now, the documentation is hosted on [RSpec](https://rspec.info/documentation/)

Changes: 
- Updated links in `rspec-test.yml` file to reflect the new hosting location.