### PR TITLE
Fix `rspec-test`'s `include` glob example

### DIFF
--- a/src/commands/rspec-test.yml
+++ b/src/commands/rspec-test.yml
@@ -4,7 +4,7 @@ parameters:
         default: "spec/**/*_spec.rb"
         description: >
             Glob to define where your test files are kept within your repository.
-            Should multiple globs be required, they must be passed in a comma separated string (e.g.: "spec/**/*_spec.rb,spec2/**/*_spec.rb").
+            Should multiple globs be required, they must be passed in a comma separated string (e.g.: "{spec/**/*_spec.rb,spec2/**/*_spec.rb}").
         type: string
     label:
         default: "RSpec Tests"


### PR DESCRIPTION
The following changes have been added to `rspec-test` in 2.1.0. 

- https://github.com/CircleCI-Public/ruby-orb/pull/129

This has changed the way `include` glob option is expanded.

For example, the description of the `include` option shows `spec/**/*_spec.rb,spec2/**/*_spec.rb` as an example, which will no longer work with the current implementation. Now this glob pattern does not find any test files. The correct value is `{spec/**/*_spec.rb,spec2/**/*_spec.rb}`, (or maybe `spec/**/*_spec.rb spec2/**/*_spec.rb` could work too).

IMHO the change in 2.1.0 is a breaking change that is not backward compatible. At least in our project, the tests stopped working as a result of the change to this version. At any rate, I think it is better to fix the example value, so I have submitted this pull request.