### PR TITLE
Try getting GPG keys from a larger pool of servers

### DIFF
--- a/src/scripts/install-rvm.sh
+++ b/src/scripts/install-rvm.sh
@@ -5,20 +5,40 @@ mkdir -p ~/.gnupg/
 find ~/.gnupg -type d -exec chmod 700 {} \;
 echo "disable-ipv6" >> ~/.gnupg/dirmngr.conf
 
-count=0
-until gpg --keyserver hkp://keyserver.ubuntu.com --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
-do
-    count=$((count+1)); sleep 10;
-    if [ $count -gt 2 ]; then
-        echo "Unable to receive GPG keys, FAILING";
-        exit 1;
-    fi;
-    echo "Network error: Unable to receive GPG keys. Will attempt again ($count/3)";
-done;
+# https://stackoverflow.com/questions/69344989/gpg-no-keyserver-available
+declare -a keyservers=(
+  "keys.openpgp.org"
+  "hkp://keyserver.ubuntu.com:80"
+  "keyserver.ubuntu.com"
+  "ha.pool.sks-keyservers.net"
+  "hkp://ha.pool.sks-keyservers.net:80"
+  "p80.pool.sks-keyservers.net"
+  "hkp://p80.pool.sks-keyservers.net:80"
+  "pgp.mit.edu"
+  "hkp://pgp.mit.edu:80"
+)
+
+gpg_key_downloaded="false"
+for server in "${keyservers[@]}"; do
+  echo "Fetching GPG keys from ${server}:"
+  gpg --keyserver $server --keyserver-options timeout=10 --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
+  if [ $? -eq 0 ]; then
+    echo "- GPG Keys successfully added from server '${server}'"
+    gpg_key_downloaded="true"
+    break
+  else
+    echo "- Network error: Unable to receive GPG keys from server '${server}'."
+  fi
+done
+if [ "$gpg_key_downloaded" = "false" ]; then
+  echo "Unable to receive GPG keys from any of the known servers, FAILING"
+  exit 1
+fi
+
 ## Update if RVM is installed and exit
 if [ -x "$(command -v rvm -v)" ]; then
-    rvm get stable
-    exit 0
+  rvm get stable
+  exit 0
 fi
 
 curl -sSL "https://get.rvm.io" | bash -s stable


### PR DESCRIPTION
The Ubuntu keyserver is often unavailable, making the ORB fail (especially from m1 machines - the default keyserver for macos is "keys.openpgp.org"). 

This PR attempts getting the GPG keys from a larger pool of known key servers.
It also adds a fallback import from rvm.io as [suggested here](https://rvm.io/rvm/security#alternatives).

Finally, it calls `gpg --import-ownertrust` as [suggested here](https://rvm.io/rvm/security#trust-our-keys)