### PR TITLE
Warning when installing ruby when rbenv is installed

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,7 +134,7 @@ workflows:
       - install-on-machine:
           matrix:
             parameters:
-              image: [ubuntu-2004:202111-02]
+              image: [ubuntu-2004:202111-02,ubuntu-2004:current]
           filters: *filters
       - test-openssl-3
       - install-on-node:

--- a/src/scripts/install-rvm.sh
+++ b/src/scripts/install-rvm.sh
@@ -48,3 +48,35 @@ else
   # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
   echo "source $RVM_HOME/scripts/rvm" >> ~/.bashrc
 fi
+
+# check if it seems like they're using rbenv already
+if command -v rbenv &> /dev/null && [ -f ".ruby-version" ]
+then
+    echo -e "\e[91m"
+    cat <<'SUGGESTION'
+
+#######################################################################
+# WARNING
+#######################################################################
+
+We've detected that you're running on a system that has the rbenv ruby
+version manager already installed, and you have a .ruby-version file in
+the current working directory.
+
+The circleci/ruby orb (that's currently executing) uses RVM to install
+ruby.  Using more than one ruby version manager at once can, depending
+on the configuration of your system, cause issues.
+
+To install ruby with rbenv without using the circleci/ruby's "install"
+command, you can simply run a step that executes:
+
+  rbenv install
+
+Which will install the version of ruby that is specified in the
+.ruby-version file.
+
+#######################################################################
+
+SUGGESTION
+    echo -e "\e[0m"
+fi


### PR DESCRIPTION
Give a warning about installing ruby with the orb's "install" command when rbenv is already installed on the box (since the installation processes uses rvm, and we've seen that these can possibly conflict and cause failure.)