### PR TITLE
set RVM home location and update --with-openssl-dir to reference it

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -124,6 +124,8 @@ jobs:
         - run:
             name: "Test Install"
             command: ruby --version | grep "2.7.0"
+        - store_artifacts:
+            path: /home/circleci/.rvm/log
 
 workflows:
   test-deploy:

--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -7,9 +7,19 @@ if bundle config set > /dev/null 2>&1; then
   bundle config gemfile "$PARAM_GEMFILE"
   bundle config path "$PARAM_PATH"
 
-  if [ -d "$HOME/.rvm/usr/ssl" ]; then
-    echo "Detected rvm ssl version. Configuring bundle package with openssl dir $HOME/.rvm/usr."
-    bundle config build.openssl --with-openssl-dir="$HOME/.rvm/usr"
+  if [ -d /opt/circleci/.rvm ]; then
+    RVM_HOME=/opt/circleci/.rvm
+  else
+    # Most circle builds run as a root user, in which case rvm gets installed in /usr/local/rvm instead of $HOME/.rvm
+    RVM_HOME=$HOME/.rvm
+    if [ ! -f "$RVM_HOME/scripts/rvm" ]; then
+      RVM_HOME=/usr/local/rvm
+    fi
+  fi
+
+  if [ -d "$RVM_HOME/usr/ssl" ]; then
+    echo "Detected rvm ssl version. Configuring bundle package with openssl dir $RVM_HOME/usr."
+    bundle config build.openssl --with-openssl-dir="$RVM_HOME/usr"
   fi
 else
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
@@ -18,9 +28,9 @@ else
   bundle config set gemfile "$PARAM_GEMFILE"
   bundle config set path "$PARAM_PATH"
 
-  if [ -d "$HOME/.rvm/usr/ssl" ]; then
-    echo "Detected rvm ssl version. Configuring bundle package with openssl dir $HOME/.rvm/usr."
-    bundle config set build.openssl --with-openssl-dir="$HOME/.rvm/usr"
+  if [ -d "$RVM_HOME/usr/ssl" ]; then
+    echo "Detected rvm ssl version. Configuring bundle package with openssl dir $RVM_HOME/usr."
+    bundle config set build.openssl --with-openssl-dir="$RVM_HOME/usr"
   fi
 fi
 

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -6,7 +6,8 @@ if ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'
 then 
     echo "Did not find supported openssl version. Installing Openssl rvm package."
     rvm pkg install openssl
-    WITH_OPENSSL="--with-openssl-dir=$HOME/.rvm/usr"
+    # location of RVM is expected to be available at RVM_HOME env var
+    WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
 fi
 
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"

--- a/src/scripts/install-rvm.sh
+++ b/src/scripts/install-rvm.sh
@@ -31,6 +31,7 @@ if [ -d /opt/circleci/.rvm ]; then
   echo "source /opt/circleci/.rvm/scripts/rvm" >> $BASH_ENV
   # this will source if anyone logs in noninteractively, nvm setup only adds nvm to the path, to get the rubygems later you need to source this again
   echo "source /opt/circleci/.rvm/scripts/rvm" >> ~/.bashrc
+  echo "export RVM_HOME=/opt/circleci/.rvm" >> $BASH_ENV
 else
   # Most circle builds run as a root user, in which case rvm gets installed in /usr/local/rvm instead of $HOME/.rvm
   RVM_HOME=$HOME/.rvm
@@ -40,6 +41,7 @@ else
     RVM_HOME=/usr/local/rvm
     echo "Using $RVM_HOME"
   fi
+  echo "export RVM_HOME=$RVM_HOME" >> $BASH_ENV
 
   echo "Setting PATH up for local install"
   # this should be what needs to be added to that $BASH_ENV since this is what's in bash_profile - i dont know when $HOME is set


### PR DESCRIPTION
This PR resolves #137

The changes made are to the `install` & `install-deps` commands.
Specifically, I

1. set the RVM home location on a `RVM_HOME` env var, addressing the case when RVM is installed in /usr/local/rvm when user is root.
2. update the various OpenSSL-related patches (`--with-openssl-dir`) so that we are pointing to the right RVM home.

I have made an accompanying build here that shows **using the fix on this branch** worked for both Docker executor (+ non-root user) & a Machine Runner (+ root user) jobs:
https://app.circleci.com/pipelines/github/kelvintaywl-cci/machine-runner-explore/36/workflows/ab4ae82f-3aeb-41ff-b9fd-143d792b74b7

You can see this accompanying workflow's code changes here:
https://github.com/kelvintaywl-cci/machine-runner-explore/compare/ruby-orb...ruby-orb-use-fixed?expand=1

(context)
- https://github.com/kelvintaywl-cci/machine-runner-explore/tree/ruby-orb is the branch where I showed the original error seen in #137 
- https://github.com/kelvintaywl-cci/machine-runner-explore/tree/ruby-orb-use-fixed is the branch where I apply the fixes seen here to the Ruby orb + run a Docker executor job for control (check non-regression)

(Copied from @kelvintaywl #138 due to difficulties)