### PR TITLE
Fix clean-bundle check in ruby/install-deps command

### DIFF
--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -34,7 +34,7 @@ else
   fi
 fi
 
-if [ "$PARAM_CLEAN_BUNDLE" = 1 ]; then
+if [ "$PARAM_CLEAN_BUNDLE" = true ]; then
   bundle check || (bundle install && bundle clean --force)
 else
   bundle check || bundle install


### PR DESCRIPTION
When enabling the clean-bundle it will not call `bundle clean --force` after installing the gems. This is especially noticeable after a ruby version bump, where the cache size doubles.

The boolean parameters you pass to the orb will just translate to true/false in the shell.