### PR TITLE
Change parallel settings

### DIFF
--- a/src/commands/rubocop-check.yml
+++ b/src/commands/rubocop-check.yml
@@ -23,7 +23,7 @@ parameters:
   parallel:
     description: >
       Use available CPUs to execute inspection in parallel.
-    default: false
+    default: true
     type: boolean
 steps:
   - run:

--- a/src/scripts/rubocop-check.sh
+++ b/src/scripts/rubocop-check.sh
@@ -2,13 +2,24 @@
 
 mkdir -p "$PARAM_OUT_PATH"
 
+RUBOCOP_VERSION=$(bundle exec rubocop -v)
+RUBOCOP_VERSION_MAJOR=$(echo "$RUBOCOP_VERSION" | cut -d. -f1)
+RUBOCOP_VERSION_MINOR=$(echo "$RUBOCOP_VERSION" | cut -d. -f2)
+
 if [ "$PARAM_PARALLEL" -eq 1 ]; then
   bundle exec rubocop "$PARAM_CHECK_PATH" \
   --format "$PARAM_FORMAT" \
+  --parallel \
   --out $"$PARAM_OUT_PATH"/check-results.xml
 else
-  bundle exec rubocop "$PARAM_CHECK_PATH" \
-  --format "$PARAM_FORMAT" \
-  --no-parallel \
-  --out $"$PARAM_OUT_PATH"/check-results.xml
+  if [ "$RUBOCOP_VERSION_MAJOR" -gt 1 ] || { [ "$RUBOCOP_VERSION_MAJOR" -eq 1 ] && [ "$RUBOCOP_VERSION_MINOR" -ge 13 ]; }; then
+    bundle exec rubocop "$PARAM_CHECK_PATH" \
+    --format "$PARAM_FORMAT" \
+    --no-parallel \
+    --out $"$PARAM_OUT_PATH"/check-results.xml
+  else
+    bundle exec rubocop "$PARAM_CHECK_PATH" \
+    --format "$PARAM_FORMAT" \
+    --out $"$PARAM_OUT_PATH"/check-results.xml
+  fi
 fi

--- a/src/scripts/rubocop-check.sh
+++ b/src/scripts/rubocop-check.sh
@@ -2,7 +2,7 @@
 
 mkdir -p "$PARAM_OUT_PATH"
 
-if [ "$PARAM_PARALLEL" -eq 0 ]; then
+if [ "$PARAM_PARALLEL" -eq 1 ]; then
   bundle exec rubocop "$PARAM_CHECK_PATH" \
   --out $"$PARAM_OUT_PATH"/check-results.xml \
   --format "$PARAM_FORMAT"
@@ -10,5 +10,5 @@ else
   bundle exec rubocop "$PARAM_CHECK_PATH" \
   --out $"$PARAM_OUT_PATH"/check-results.xml \
   --format "$PARAM_FORMAT" \
-  --parallel
+  --no-parallel
 fi


### PR DESCRIPTION
In the current state of Rubocop, parallel settings appear to be enabled by default. Therefore, this setting is also enabled by default.

https://docs.rubocop.org/rubocop/usage/basic_usage.html#command-line-flags

In the documentation, the default in orb is stated as false, but I think the actual behaviour is parallel operation. For users who explicitly stated false, this would change the behaviour. However, I would like the orbs default behaviour to be aligned with the default behaviour of Rubocop.

There is an idea to abolish <<parameters.parallel>> and introduce <<parameters.no-parallel>>, although this would force existing configuration changes when updating orb.

If this is better, please point this out.