### PR TITLE
Feature: add openssl path param

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,6 +23,22 @@ executors:
       image: << parameters.image >>
 
 jobs:
+  test-openssl-installed:
+    docker:
+      - image: cimg/node:16.18.0
+    steps:
+      - run: 
+          name: Install OpenSSL 1.1.1
+          command: |
+            wget https://openssl.org/source/openssl-1.1.1.tar.gz
+            tar -xzvf openssl-1.1.1.tar.gz
+            cd openssl-1.1.1
+            ./config
+            make
+            sudo make install
+      - ruby/install:
+          version: 2.7.6
+          openssl-path: /usr/local/ssl
   test-openssl-3:
     docker:
       - image: cimg/node:16.18.0
@@ -136,6 +152,11 @@ workflows:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
       - integration-tests:
           filters: *filters
+      - test-openssl-installed:
+          filters: *filters
+          post-steps:
+          - run: |
+              ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
       - install-on-machine:
           matrix:
             parameters:

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -7,6 +7,12 @@ parameters:
       You can also pass in a string to be evaluated.
       For example, `${MY_RUBY_VERSION}` or `$(cat foo/bar/.ruby-version)`.
     type: string
+  openssl-path:
+    description: >
+      Directory where OpenSSL is intalled.
+      This will overwrite the value of --with-openssl-dir in the rvm install commmand.
+      Set this if you need to use an OpenSSL version different to 1.0.1 (rvm default).
+      The version must be already installed.
 steps:
   - run:
       name: "Install/Verify Ruby Version Manager."
@@ -16,4 +22,5 @@ steps:
       name: "Install Ruby v<< parameters.version >> via RVM"
       environment:
         PARAM_VERSION: << parameters.version >>
+        PARAM_OPENSSL_PATH: << parameters.openssl-path> >
       command: << include(scripts/install-ruby.sh) >>

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -13,6 +13,8 @@ parameters:
       This will overwrite the value of --with-openssl-dir in the rvm install commmand.
       Set this if you need to use an OpenSSL version different to 1.0.1 (rvm default).
       The version must be already installed.
+    type: string
+    default: ""
 steps:
   - run:
       name: "Install/Verify Ruby Version Manager."

--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -24,5 +24,5 @@ steps:
       name: "Install Ruby v<< parameters.version >> via RVM"
       environment:
         PARAM_VERSION: << parameters.version >>
-        PARAM_OPENSSL_PATH: << parameters.openssl-path> >
+        PARAM_OPENSSL_PATH: << parameters.openssl-path >>
       command: << include(scripts/install-ruby.sh) >>

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -2,8 +2,10 @@
 
 PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
 
-if ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+' 
-then 
+if [ -n "$PARAM_OPENSSL_PATH" ]; then
+    echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
+    WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
+elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
     echo "Did not find supported openssl version. Installing Openssl rvm package."
     rvm pkg install openssl
     # location of RVM is expected to be available at RVM_HOME env var


### PR DESCRIPTION
This could solve the issue presented in #132 where the OpenSSL version used by default does not work in some situations.