### PR TITLE
Use realpath for the Gemfile path.

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -48,7 +48,7 @@ parameters:
       Specify an alternative file to use in the cache key
   gemfile:
     description: Name of your Gemfile file.
-    default: ""
+    default: Gemfile
     type: string
   pre-install-steps:
     description: >

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -48,7 +48,7 @@ parameters:
       Specify an alternative file to use in the cache key
   gemfile:
     description: Name of your Gemfile file.
-    default: Gemfile
+    default: ""
     type: string
   pre-install-steps:
     description: >

--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -4,7 +4,7 @@ if bundle config set > /dev/null 2>&1; then
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config deployment 'true'
   fi
-  if [ -n "$PARAM_GEMFILE" ]; then
+  if [ "$PARAM_GEMFILE" != "Gemfile" ]; then
     bundle config gemfile "$PARAM_GEMFILE"
   fi
   bundle config path "$PARAM_PATH"
@@ -27,7 +27,7 @@ else
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config set deployment 'true'
   fi
-  if [ -n "$PARAM_GEMFILE" ]; then
+  if [ "$PARAM_GEMFILE" != "Gemfile" ]; then
     bundle config set gemfile "$PARAM_GEMFILE"
   fi
   bundle config set path "$PARAM_PATH"

--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -1,12 +1,10 @@
 #!/usr/bin/env bash
-
+GEMFILE_ABS_PATH=$(realpath "$PARAM_GEMFILE")
 if bundle config set > /dev/null 2>&1; then
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config deployment 'true'
   fi
-  if [ "$PARAM_GEMFILE" != "Gemfile" ]; then
-    bundle config gemfile "$PARAM_GEMFILE"
-  fi
+  bundle config gemfile "$GEMFILE_ABS_PATH"
   bundle config path "$PARAM_PATH"
 
   if [ -d /opt/circleci/.rvm ]; then
@@ -27,9 +25,7 @@ else
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config set deployment 'true'
   fi
-  if [ "$PARAM_GEMFILE" != "Gemfile" ]; then
-    bundle config set gemfile "$PARAM_GEMFILE"
-  fi
+  bundle config set gemfile "$GEMFILE_ABS_PATH"
   bundle config set path "$PARAM_PATH"
 
   if [ -d "$RVM_HOME/usr/ssl" ]; then

--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -4,7 +4,9 @@ if bundle config set > /dev/null 2>&1; then
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config deployment 'true'
   fi
-  bundle config gemfile "$PARAM_GEMFILE"
+  if [ -n "$PARAM_GEMFILE" ]; then
+    bundle config gemfile "$PARAM_GEMFILE"
+  fi
   bundle config path "$PARAM_PATH"
 
   if [ -d /opt/circleci/.rvm ]; then
@@ -25,7 +27,9 @@ else
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config set deployment 'true'
   fi
-  bundle config set gemfile "$PARAM_GEMFILE"
+  if [ -n "$PARAM_GEMFILE" ]; then
+    bundle config set gemfile "$PARAM_GEMFILE"
+  fi
   bundle config set path "$PARAM_PATH"
 
   if [ -d "$RVM_HOME/usr/ssl" ]; then


### PR DESCRIPTION
As indicated in #122 when the PARAM_GEMFILE is set to Gemfile by default, and setting it might cause issues when a command is executed in a different directory. This PR is intented to fix that behavior.