### PR TITLE
add resource class to default executor

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -28,7 +28,7 @@ jobs:
       executor:
         type: executor
         default: ruby/default
-    executor: <<parameter.executor>>
+    executor: <<parameters.executor>>
     steps:
       - checkout
       - ruby/install-deps:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -23,6 +23,17 @@ executors:
       image: << parameters.image >>
 
 jobs:
+  install-deps:
+    parameters:
+      executor:
+        type: executor
+        default: ruby/default
+    executor: <<parameter.executor>>
+    steps:
+      - checkout
+      - ruby/install-deps:
+          app-dir: sample
+          with-cache: false
   test-openssl-installed:
     docker:
       - image: cimg/node:16.18.0
@@ -166,6 +177,18 @@ workflows:
   test-deploy:
     jobs:
       # Make sure to include "filters: *filters" in every test job you want to run as part of your deployment.
+      - install-deps:
+          name: install-deps-medium
+          executor:
+            name: ruby/default
+            resource_class: medium
+          filters: *filters
+      - install-deps:
+          name: install-deps-large
+          executor:
+            name: ruby/default
+            resource_class: large
+          filters: *filters
       - integration-tests:
           filters: *filters
       - test-openssl-installed:

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -6,5 +6,11 @@ parameters:
     description: "The `cimg/ruby` Docker image version tag."
     type: string
     default: "2.7"
+  resource_class: 
+    description: The resources_class of the instance to run on. Defaults to Medium.
+    type: string
+    default: "medium"
+
 docker:
   - image: cimg/ruby:<< parameters.tag >>
+resourc_class: << parameters.resource_class >>

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -6,11 +6,11 @@ parameters:
     description: "The `cimg/ruby` Docker image version tag."
     type: string
     default: "2.7"
-  resource_class: 
+  resource_class:
     description: The resources_class of the instance to run on. Defaults to Medium.
     type: string
     default: "medium"
 
 docker:
   - image: cimg/ruby:<< parameters.tag >>
-resourc_class: << parameters.resource_class >>
+resource_class: << parameters.resource_class >>


### PR DESCRIPTION
resolves #147 
As suggested in the issue #147 allowing to pass the resource_class to the executor is a nice to have feature.
I'm adding two tests to validate the change is working as expected.