### PR TITLE
Fix/realpath to basename

### DIFF
--- a/src/scripts/install-deps.sh
+++ b/src/scripts/install-deps.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-GEMFILE_ABS_PATH=$(realpath "$PARAM_GEMFILE")
+GEMFILE_ABS_PATH="$(cd "$(dirname "$PARAM_GEMFILE")" && pwd -P)/$(basename "$PARAM_GEMFILE")"
+
+echo "$(cd "$(dirname LICENSE)" && pwd -P)/$(basename LICENSE)"
 if bundle config set > /dev/null 2>&1; then
   if [ "$PARAM_PATH" == "./vendor/bundle" ]; then
     bundle config deployment 'true'

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,19 +1,20 @@
 #!/usr/bin/env bash
 
 PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
-RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
-RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
-detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+# RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
+# RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
+# detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
-if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
-    brew install openssl@1.1
-    OPENSSL_LOCATION="$(brew --prefix openssl@1.1)"
-    export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$OPENSSL_LOCATION"
-    rbenv install $PARAM_RUBY_VERSION
-    rbenv global $PARAM_RUBY_VERSION
-    exit 0
-fi
+# if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
+#     echo "Installing OpenSSL 1.1 with brew"
+#     brew install openssl@1.1
+#     OPENSSL_LOCATION="$(brew --prefix openssl@1.1)"
+#     export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$OPENSSL_LOCATION"
+#     rbenv install $PARAM_RUBY_VERSION
+#     rbenv global $PARAM_RUBY_VERSION
+#     exit 0
+# fi
 
 if [ -n "$PARAM_OPENSSL_PATH" ]; then
     echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -6,7 +6,7 @@ RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
-if [ "$detected_platform" = "darwin" ] && {[ "$RUBY_VERSION_MAJOR" -le 2 ] || {[ "$RUBY_VERSION_MAJOR" -eq 3 ] && [ "$RUBY_VERSION_MINOR" -eq 0 ]}}; then
+if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
     brew install openssl@1.1
     OPENSSL_LOCATION="$(brew --prefix openssl@1.1)"
     export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$OPENSSL_LOCATION"

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,20 +1,16 @@
 #!/usr/bin/env bash
 
 PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
-# RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
-# RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
-# detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
+RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
+RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
+detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
-# if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
-#     echo "Installing OpenSSL 1.1 with brew"
-#     brew install openssl@1.1
-#     OPENSSL_LOCATION="$(brew --prefix openssl@1.1)"
-#     export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$OPENSSL_LOCATION"
-#     rbenv install $PARAM_RUBY_VERSION
-#     rbenv global $PARAM_RUBY_VERSION
-#     exit 0
-# fi
+if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
+    rbenv install $PARAM_RUBY_VERSION
+    rbenv global $PARAM_RUBY_VERSION
+    exit 0
+fi
 
 if [ -n "$PARAM_OPENSSL_PATH" ]; then
     echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
@@ -25,7 +21,7 @@ elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then
     # location of RVM is expected to be available at RVM_HOME env var
     WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
 fi
-
+rvm get master
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"
 rvm use "$PARAM_RUBY_VERSION"
 

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -2,8 +2,11 @@
 
 PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
 RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
+RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
-if [ "$detected_platform" = "darwin" ] && [ "$RUBY_VERSION_MAJOR" -le 2 ]; then
+
+# When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
+if [ "$detected_platform" = "darwin" ] && {[ "$RUBY_VERSION_MAJOR" -le 2 ] || {[ "$RUBY_VERSION_MAJOR" -eq 3 ] && [ "$RUBY_VERSION_MINOR" -eq 0 ]}}; then
     brew install openssl@1.1
     OPENSSL_LOCATION="$(brew --prefix openssl@1.1)"
     export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$OPENSSL_LOCATION"

--- a/src/scripts/install-rvm.sh
+++ b/src/scripts/install-rvm.sh
@@ -57,7 +57,7 @@ echo 7D2BAF1CF37B13E2069D6956105BD0E739499BDB:6: | gpg --import-ownertrust
 
 ## Update if RVM is installed and exit
 if [ -x "$(command -v rvm -v)" ]; then
-  rvm get stable
+  rvm get head
   exit 0
 fi
 


### PR DESCRIPTION
I'm fixing the issue mentioned in this [PR](https://github.com/CircleCI-Public/ruby-orb/pull/151#issuecomment-2485101206) by updating the way to get the absolute path of the Gemfile.

I'm also doing some fixes at the ruby installation command as the OpenSSL 1.1 is fully removed now.