### PR TITLE
Update openssl installation method

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,7 +163,7 @@ jobs:
     docker:
         - image: <<parameters.image>>
     steps:
-      - run: apt update -y && apt install curl -y
+      - run: apt update -y && apt install curl gnupg2 -y
       - ruby/install:
           version: << parameters.version >>
       - run:
@@ -231,7 +231,7 @@ workflows:
       - install-on-docker:
           matrix:
             parameters:
-              image: ["cimg/base:current", "debian:bookworm-slim"]
+              image: ["debian:bookworm-slim"]
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - test-openssl-3:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -230,7 +230,7 @@ workflows:
       - install-on-docker:
           matrix:
             parameters:
-              image: ["cimg/base:current", "alpine"]
+              image: ["cimg/base:current", "debian:bookworm-slim"]
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - test-openssl-3:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -218,14 +218,15 @@ workflows:
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-              cd "$HOME/project/sample"
-              bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+              # cd "$HOME/project/sample"
+              # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-on-macos:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
@@ -234,8 +235,9 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
@@ -245,8 +247,9 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: ["debian:bookworm-slim"]
@@ -256,22 +259,25 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
           filters: *filters
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/project/sample"
-                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  # cd "$HOME/project/sample"
+                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,7 +163,7 @@ jobs:
     docker:
         - image: <<parameters.image>>
     steps:
-      - run: apt update -y && apt install curl gnupg2 -y
+      - run: apt update -y && apt install curl gnupg2 procps -y
       - ruby/install:
           version: << parameters.version >>
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -213,21 +213,18 @@ workflows:
       - integration-tests:
           filters: *filters
       - test-openssl-installed:
-          post-steps:
-            - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3      
           filters: *filters
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+              cd sample
+              bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-on-macos:
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
@@ -235,9 +232,9 @@ workflows:
       - install-on-machine:
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
@@ -246,9 +243,9 @@ workflows:
       - install-on-docker:
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: ["debian:bookworm-slim"]
@@ -257,23 +254,23 @@ workflows:
       - test-openssl-3:
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
           filters: *filters
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
           post-steps:
             - run:
-              command: |
-                cd sample
-                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
+                command: |
+                  cd sample
+                  bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -152,6 +152,22 @@ jobs:
       - run:
           name: "Test Install"
           command: ruby --version | grep << parameters.version >>
+  install-on-docker:
+    parameters:
+      image:
+        description: Enter the version that should be used for the machine executor.
+        type: string
+      version:
+        description: Version to install
+        type: string
+    docker:
+        - image: <<parameters.image>>
+    steps:
+      - ruby/install:
+          version: << parameters.version >>
+      - run:
+          name: "Test Install"
+          command: ruby --version | grep << parameters.version >>
   install-on-node:
       docker:
         - image: cimg/node:current
@@ -209,6 +225,12 @@ workflows:
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
+              version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
+          filters: *filters
+      - install-on-docker:
+          matrix:
+            parameters:
+              image: ["cimg/base:current", "alpine"]
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - test-openssl-3:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -217,12 +217,12 @@ workflows:
           filters: *filters
           post-steps:
           - run: |
-              ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+              ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
       - install-on-macos:
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
           matrix:
             parameters:
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
@@ -231,7 +231,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
@@ -241,7 +241,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
           matrix:
             parameters:
               image: ["debian:bookworm-slim"]
@@ -251,19 +251,19 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
           filters: *filters
       - install-on-node:
           filters: *filters
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
       - install-from-env-var:
           post-steps:
             - run:
                 command: |
-                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
+                  ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected: #{OpenSSL::OPENSSL_VERSION}"; exit 0; end'
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -168,7 +168,7 @@ jobs:
           version: << parameters.version >>
       - run:
           name: "Test Install"
-          command: ruby --version | grep << parameters.version >> && openssl version
+          command: ruby --version | grep << parameters.version >>
   install-on-node:
       docker:
         - image: cimg/node:current
@@ -213,32 +213,67 @@ workflows:
       - integration-tests:
           filters: *filters
       - test-openssl-installed:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3      
           filters: *filters
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
       - install-on-macos:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
           filters: *filters
       - install-on-machine:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - install-on-docker:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: ["debian:bookworm-slim"]
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - test-openssl-3:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
           filters: *filters
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
+          post-steps:
+            - run:
+              command: |
+                cd sample
+                bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -218,15 +218,11 @@ workflows:
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-              # cd "$HOME/project/sample"
-              # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-on-macos:
           post-steps:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
@@ -236,8 +232,6 @@ workflows:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
@@ -248,8 +242,6 @@ workflows:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
               image: ["debian:bookworm-slim"]
@@ -260,8 +252,6 @@ workflows:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
           filters: *filters
@@ -269,15 +259,11 @@ workflows:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
           post-steps:
             - run:
                 command: |
                   ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-                  # cd "$HOME/project/sample"
-                  # bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:
           filters: *release-filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,7 +163,7 @@ jobs:
     docker:
         - image: <<parameters.image>>
     steps:
-      - run: apt update && apt install curl
+      - run: apt update -y && apt install curl -y
       - ruby/install:
           version: << parameters.version >>
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -218,13 +218,13 @@ workflows:
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-              cd "$HOME/sample"
+              cd "$HOME/project/sample"
               bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-on-macos:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -234,7 +234,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -245,7 +245,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -256,7 +256,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
@@ -264,13 +264,13 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
           post-steps:
             - run:
                 command: |
-                  cd "$HOME/sample"
+                  cd "$HOME/project/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,7 +163,7 @@ jobs:
     docker:
         - image: <<parameters.image>>
     steps:
-      - run: apt install curl
+      - run: apt update && apt install curl
       - ruby/install:
           version: << parameters.version >>
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -163,6 +163,7 @@ jobs:
     docker:
         - image: <<parameters.image>>
     steps:
+      - run: apt install curl
       - ruby/install:
           version: << parameters.version >>
       - run:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -47,6 +47,7 @@ jobs:
             ./config
             make
             sudo make install
+            cd ..
       - ruby/install:
           version: 2.7.6
           openssl-path: /usr/local/ssl
@@ -217,13 +218,13 @@ workflows:
           post-steps:
           - run: |
               ruby -ropenssl -e 'if OpenSSL::OPENSSL_VERSION.include?("OpenSSL 1.1.1"); puts "Version 1.1.1 detected"; else; puts "Different version detected"; exit 0; end'
-              cd sample
+              cd "$HOME/sample"
               bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-on-macos:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -233,7 +234,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -244,7 +245,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           matrix:
             parameters:
@@ -255,7 +256,7 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - install-on-node:
@@ -263,13 +264,13 @@ workflows:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
       - install-from-env-var:
           post-steps:
             - run:
                 command: |
-                  cd sample
+                  cd "$HOME/sample"
                   bundle config set --local deployment 'true' && bundle install --jobs=2 --retry=3
           filters: *filters
       - orb-tools/pack:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -203,13 +203,13 @@ workflows:
       - install-on-macos:
           matrix:
             parameters:
-              version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5"]
+              version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "3.3.5"]
           filters: *filters
       - install-on-machine:
           matrix:
             parameters:
               image: [ubuntu-2004:202111-02,ubuntu-2004:current]
-              version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6"]
+              version: ["2.7.6", "3.0.7", "3.1.6", "3.2.5", "2.6", "3.3.5"]
           filters: *filters
       - test-openssl-3:
           filters: *filters

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -168,9 +168,7 @@ jobs:
           version: << parameters.version >>
       - run:
           name: "Test Install"
-          command: |
-            ruby --version | grep << parameters.version >>
-            openssl version
+          command: ruby --version | grep << parameters.version >> && openssl version
   install-on-node:
       docker:
         - image: cimg/node:current

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -168,7 +168,9 @@ jobs:
           version: << parameters.version >>
       - run:
           name: "Test Install"
-          command: ruby --version | grep << parameters.version >>
+          command: |
+            ruby --version | grep << parameters.version >>
+            openssl version
   install-on-node:
       docker:
         - image: cimg/node:current

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -12,9 +12,9 @@ if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RU
     exit 0
 fi
 
-if [ -n "$PARAM_OPENSSL_PATH" ]; then
-    echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
-    WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
+# if [ -n "$PARAM_OPENSSL_PATH" ]; then
+#     echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
+#     WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
 # elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
 #     echo "Did not find supported openssl version. Installing Openssl rvm package."
 #     rvm pkg install openssl

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -20,7 +20,7 @@ fi
 #     rvm pkg install openssl
 #     # location of RVM is expected to be available at RVM_HOME env var
 #     WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
-fi
+# fi
 rvm get master
 rvm autolibs enable
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -15,13 +15,14 @@ fi
 if [ -n "$PARAM_OPENSSL_PATH" ]; then
     echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
     WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
-elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
-    echo "Did not find supported openssl version. Installing Openssl rvm package."
-    rvm pkg install openssl
-    # location of RVM is expected to be available at RVM_HOME env var
-    WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
+# elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
+#     echo "Did not find supported openssl version. Installing Openssl rvm package."
+#     rvm pkg install openssl
+#     # location of RVM is expected to be available at RVM_HOME env var
+#     WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
 fi
 rvm get master
+rvm autolibs enable
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"
 rvm use "$PARAM_RUBY_VERSION"
 

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
-set -x
-echo "$PARAM_VERSION"
 PARAM_RUBY_VERSION="$(echo "$PARAM_VERSION" | circleci env subst)"
-RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
-RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
+RUBY_VERSION_MAJOR=$(echo "$PARAM_RUBY_VERSION" | cut -d. -f1)
+RUBY_VERSION_MINOR=$(echo "$PARAM_RUBY_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
-set +x
+
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
 if [[ "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ]]; then
     if [[ "$detected_platform" = "darwin" ]]; then

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
+PARAM_RUBY_VERSION="$(echo "$PARAM_VERSION" | circleci env subst)"
 RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
 RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -6,23 +6,27 @@ RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
-if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
-    rbenv install $PARAM_RUBY_VERSION
-    rbenv global $PARAM_RUBY_VERSION
-    exit 0
+if [[ ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
+    if [[ "$detected_platform" = "darwin" ]]; then
+        rbenv install $PARAM_RUBY_VERSION
+        rbenv global $PARAM_RUBY_VERSION
+        exit 0
+    else
+        if [ -n "$PARAM_OPENSSL_PATH" ]; then
+            echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
+            WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
+        elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
+            echo "Did not find supported openssl version. Installing Openssl rvm package."
+            rvm pkg install openssl
+            # location of RVM is expected to be available at RVM_HOME env var
+            WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
+        fi
+    fi
+else
+    rvm autolibs enable
 fi
 
-if [ -n "$PARAM_OPENSSL_PATH" ]; then
-    echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
-    WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
-elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
-    echo "Did not find supported openssl version. Installing Openssl rvm package."
-    rvm pkg install openssl
-    # location of RVM is expected to be available at RVM_HOME env var
-    WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
-fi
 rvm get master
-# rvm autolibs enable
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"
 rvm use "$PARAM_RUBY_VERSION"
 

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
-
+set -x
+echo "$PARAM_VERSION"
 PARAM_RUBY_VERSION="$(echo "$PARAM_VERSION" | circleci env subst)"
 RUBY_VERSION_MAJOR=$(echo "$PARAM_VERSION" | cut -d. -f1)
 RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
-
+set +x
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
 if [[ "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ]]; then
     if [[ "$detected_platform" = "darwin" ]]; then

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -12,17 +12,17 @@ if [[ "$detected_platform" = "darwin" && ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RU
     exit 0
 fi
 
-# if [ -n "$PARAM_OPENSSL_PATH" ]; then
-#     echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
-#     WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
-# elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
-#     echo "Did not find supported openssl version. Installing Openssl rvm package."
-#     rvm pkg install openssl
-#     # location of RVM is expected to be available at RVM_HOME env var
-#     WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
-# fi
+if [ -n "$PARAM_OPENSSL_PATH" ]; then
+    echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
+    WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
+elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
+    echo "Did not find supported openssl version. Installing Openssl rvm package."
+    rvm pkg install openssl
+    # location of RVM is expected to be available at RVM_HOME env var
+    WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
+fi
 rvm get master
-rvm autolibs enable
+# rvm autolibs enable
 rvm install "$PARAM_RUBY_VERSION" "$WITH_OPENSSL"
 rvm use "$PARAM_RUBY_VERSION"
 

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -6,7 +6,7 @@ RUBY_VERSION_MINOR=$(echo "$PARAM_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"
 
 # When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
-if [[ ( "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ) ]]; then
+if [[ "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ]]; then
     if [[ "$detected_platform" = "darwin" ]]; then
         rbenv install $PARAM_RUBY_VERSION
         rbenv global $PARAM_RUBY_VERSION


### PR DESCRIPTION
resolves #159 
I'm updating the script that installs openssl, to add a new method using `rvm autolibs enable` for the newer versions of ruby that don't support `rvm pkg`

I'm also updating the tests to show what version of OpenSSL is being installed in each test case.