### PR TITLE
Revert version eval on install

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -47,7 +47,6 @@ jobs:
             ./config
             make
             sudo make install
-            cd ..
       - ruby/install:
           version: 2.7.6
           openssl-path: /usr/local/ssl

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-PARAM_RUBY_VERSION="$(echo "$PARAM_VERSION" | circleci env subst)"
+PARAM_RUBY_VERSION=$(eval echo "${PARAM_VERSION}")
 RUBY_VERSION_MAJOR=$(echo "$PARAM_RUBY_VERSION" | cut -d. -f1)
 RUBY_VERSION_MINOR=$(echo "$PARAM_RUBY_VERSION" | cut -d. -f2)
 detected_platform="$(uname -s | tr '[:upper:]' '[:lower:]')"


### PR DESCRIPTION
resolves #161 

Last update (v2.5.1) removed the capacity to pass commands to the version, I'm reverting that.