### PR TITLE
Trim period from step name installing RVM

### DIFF
--- a/src/commands/install.yml
+++ b/src/commands/install.yml
@@ -17,7 +17,7 @@ parameters:
     default: ""
 steps:
   - run:
-      name: "Install/Verify Ruby Version Manager."
+      name: "Install/Verify Ruby Version Manager"
       command: << include(scripts/install-rvm.sh) >>
 
   - run:


### PR DESCRIPTION
Other step names don't have a period. This aims to keep consistency.

For example:
https://github.com/CircleCI-Public/ruby-orb/blob/f95edbc9c3f1623fa65110499f3ac60a8b96ed67/src/commands/install.yml#L24

Here's an actual example on CircleCI:

<img width="542" alt="image" src="https://github.com/user-attachments/assets/2b3905f2-b312-490a-b3c4-5a67d0b94523" />
