### PR TITLE
Provide DEPENDENCY_NEXT Support for Cache Key Generation

### DIFF
--- a/src/scripts/determine-lockfile.sh
+++ b/src/scripts/determine-lockfile.sh
@@ -9,6 +9,9 @@ fi
 if [ -n "$PARAM_OVERRIDE_LOCKFILE" ] && [ -f "$PARAM_OVERRIDE_LOCKFILE" ]; then
     echo "Using $PARAM_OVERRIDE_LOCKFILE as lock file"
     cp "$PARAM_OVERRIDE_LOCKFILE" $TARGET_DIR/ruby-project-lockfile
+elif [ -n "$DEPENDENCIES_NEXT" ] && [ -f "Gemfile_next.lock" ]; then
+    echo "Using Gemfile_next.lock as lock file"
+    cp Gemfile_next.lock $TARGET_DIR/ruby-project-lockfile
 elif [[ "$PARAM_GEMFILE" == *.rb ]]; then
     GEMS_LOCKED="${PARAM_GEMFILE%.rb}.locked"
 
@@ -21,6 +24,6 @@ elif [[ "$PARAM_GEMFILE" == *.rb ]]; then
 elif [ -f "$PARAM_GEMFILE.lock" ]; then
     echo "Using $PARAM_GEMFILE.lock as lock file"
     cp "$PARAM_GEMFILE.lock" $TARGET_DIR/ruby-project-lockfile
-else 
+else
     echo "Unable to determine lock file for $PARAM_GEMFILE."
 fi


### PR DESCRIPTION
Bootboot is a gem commonly used for allowing a Rails application to be dual booted during a major change, such as a version upgrade. The gem relies on an env variable "DEPENDENCIES_NEXT" for determining which lock file should be used. It would be nice if the determine-lockfile script could do the same. That is that when DEPEDENCIES_NEXT is set, determine-lockfile will copy Gemfile_next.lock instead of Gemfile.lock.