### PR TITLE
Allow for usage of only a Gemfile based cache key

### DIFF
--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -4,7 +4,7 @@ parameters:
     type: boolean
     default: true
     description: Enable automatic caching of your gemfile dependencies for increased speed.
-  only-gemfile-cache-key:
+  only-use-gemfile-checksum-cache-key:
     type: boolean
     default: false
     description: When enabled only uses the cache key that contains the Gemile.lock checksum for restoring cache.
@@ -76,13 +76,13 @@ steps:
       condition: <<parameters.with-cache>>
       steps:
         when:
-          condition: << parameters.only-gemfile-cache-key >>
+          condition: << parameters.only-use-gemfile-checksum-cache-key >>
           steps:
             - restore_cache:
                 keys:
                   - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
         unless:
-          condition: << parameters.only-gemfile-cache-key >>
+          condition: << parameters.only-use-gemfile-checksum-cache-key >>
           steps:
             - restore_cache:
                 keys:

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -75,19 +75,19 @@ steps:
   - when:
       condition: <<parameters.with-cache>>
       steps:
-        when:
-          condition: << parameters.only-use-gemfile-checksum-cache-key >>
-          steps:
-            - restore_cache:
-                keys:
-                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
-        unless:
-          condition: << parameters.only-use-gemfile-checksum-cache-key >>
-          steps:
-            - restore_cache:
-                keys:
-                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
-                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
+        - when:
+            condition: << parameters.only-use-gemfile-checksum-cache-key >>
+            steps:
+              - restore_cache:
+                  keys:
+                    - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
+        - unless:
+            condition: << parameters.only-use-gemfile-checksum-cache-key >>
+            steps:
+              - restore_cache:
+                  keys:
+                    - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
+                    - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
   - run:
       name: Install Bundler
       working_directory: <<parameters.app-dir>>

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -7,7 +7,7 @@ parameters:
   only-gemfile-cache-key:
     type: boolean
     default: false
-    description: When enabled only uses the cache key that contains the Gemile.lock sha for restoring cache.
+    description: When enabled only uses the cache key that contains the Gemile.lock checksum for restoring cache.
   clean-bundle:
     description: >
       Run `bundle clean --force` after `bundle install` to clean Bundler before saving dependencies to cache.

--- a/src/commands/install-deps.yml
+++ b/src/commands/install-deps.yml
@@ -4,6 +4,10 @@ parameters:
     type: boolean
     default: true
     description: Enable automatic caching of your gemfile dependencies for increased speed.
+  only-gemfile-cache-key:
+    type: boolean
+    default: false
+    description: When enabled only uses the cache key that contains the Gemile.lock sha for restoring cache.
   clean-bundle:
     description: >
       Run `bundle clean --force` after `bundle install` to clean Bundler before saving dependencies to cache.
@@ -71,10 +75,19 @@ steps:
   - when:
       condition: <<parameters.with-cache>>
       steps:
-        - restore_cache:
-            keys:
-              - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
-              - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
+        when:
+          condition: << parameters.only-gemfile-cache-key >>
+          steps:
+            - restore_cache:
+                keys:
+                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
+        unless:
+          condition: << parameters.only-gemfile-cache-key >>
+          steps:
+            - restore_cache:
+                keys:
+                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>{{ checksum "/tmp/ruby-project-lockfile" }}
+                  - << parameters.key >>-<<#parameters.include-arch-in-cache-key>>{{ arch }}-<</parameters.include-arch-in-cache-key>><<#parameters.include-branch-in-cache-key>>{{ .Branch }}-<</parameters.include-branch-in-cache-key>>
   - run:
       name: Install Bundler
       working_directory: <<parameters.app-dir>>


### PR DESCRIPTION
The cache key fallback can lead to complications and race conditions when juggling more than 1 Gemfile.lock. To avoid this it would be nice to opt out of not using a fallback cache key and instead only rely on the cache key that contains the appropriate gemfile checksum.