### PR TITLE
Include an explicit seed value in the RSpec command

### DIFF
--- a/src/scripts/rspec-test.sh
+++ b/src/scripts/rspec-test.sh
@@ -52,9 +52,9 @@ fi
 # Leaving set -x here because it's useful for debugging what files are being tested
 set -x
   if [ "$PARAM_RERUN_FAIL" = 1 ]; then
-    circleci tests glob "${globs[@]}" | circleci tests run --command "xargs bundle exec rspec --profile 10 --format RspecJunitFormatter --out \"$PARAM_OUT_PATH\"/results.xml --format progress ${args[*]}" --verbose --split-by=timings
+    circleci tests glob "${globs[@]}" | circleci tests run --command "xargs bundle exec rspec --seed \"$RANDOM\" --profile 10 --format RspecJunitFormatter --out \"$PARAM_OUT_PATH\"/results.xml --format progress ${args[*]}" --verbose --split-by=timings
   else
     prepare_split_files
-    bundle exec rspec "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress "${args[@]}"
+    bundle exec rspec --seed "$RANDOM" "${test_files[@]}" --profile 10 --format RspecJunitFormatter --out "$PARAM_OUT_PATH"/results.xml --format progress "${args[@]}"
   fi
 set +x


### PR DESCRIPTION
This makes the `rspec` command easy to copy and paste locally for debugging flaky tests that depend on execution order.

See https://linuxsimply.com/bash-scripting-tutorial/operator/arithmetic-operators/random-number/#:~:text=1.%20Using%20“RANDOM”%20Environment%20Variable for the builtin bash `$RANDOM` variable.