### PR TITLE
chore: Disable PR comments on publish

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -289,7 +289,7 @@ workflows:
           orb_name: circleci/ruby
           vcs_type: << pipeline.project.type >>
           pub_type: production
-          enable_pr_comment: true
+          enable_pr_comment: false
           github_token: GHI_TOKEN
           requires:
             - orb-tools/pack


### PR DESCRIPTION
This should fix the issue blocking us from publishing a new version: https://app.circleci.com/pipelines/github/CircleCI-Public/ruby-orb/794/workflows/b56a30f6-5289-4e3c-aa39-16f899f0a4dc/jobs/6605