### PR TITLE
feat!: bump default Ruby executor tag 2.7 → 3.3 (PIE-6)

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -134,7 +134,7 @@ jobs:
         description: Version to install
         type: string
     macos:
-      xcode: 16.3.0
+      xcode: 16.4.0
     steps:
       - ruby/install:
           version: << parameters.version >>

--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -5,7 +5,7 @@ parameters:
   tag:
     description: "The `cimg/ruby` Docker image version tag."
     type: string
-    default: "2.7"
+    default: "3.3"
   resource_class:
     description: The resources_class of the instance to run on. Defaults to Medium.
     type: string

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -11,28 +11,26 @@ if command -v ruby >/dev/null 2>&1; then
     fi
 fi
 
-# When on MacOS, and versions minor or equal to 3.0.x. These are the versions depending on OpenSSL 1.1
+# On macOS, always use rbenv+ruby-build which carries patches for newer OpenSSL versions
+if [[ "$detected_platform" = "darwin" ]]; then
+    rbenv install $PARAM_RUBY_VERSION
+    rbenv global $PARAM_RUBY_VERSION
+    exit 0
+fi
+
+# Linux: older Ruby versions (≤3.0) depend on OpenSSL 1.1
 if [[ "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_VERSION_MINOR" -eq 0 ) ]]; then
-    if [[ "$detected_platform" = "darwin" ]]; then
-        rbenv install $PARAM_RUBY_VERSION
-        rbenv global $PARAM_RUBY_VERSION
-        exit 0
-    else
-        if [ -n "$PARAM_OPENSSL_PATH" ]; then
-            echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
-            WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
-        elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then 
-            echo "Did not find supported OpenSSL version. Installing OpenSSL rvm package."
-            rvm pkg install openssl
-            # location of RVM is expected to be available at RVM_HOME env var
-            WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
-        fi
+    if [ -n "$PARAM_OPENSSL_PATH" ]; then
+        echo "Using path $PARAM_OPENSSL_PATH for OpenSSL"
+        WITH_OPENSSL="--with-openssl-dir=$PARAM_OPENSSL_PATH"
+    elif ! openssl version | grep -q -E '1\.[0-9]+\.[0-9]+'; then
+        echo "Did not find supported OpenSSL version. Installing OpenSSL rvm package."
+        rvm pkg install openssl
+        # location of RVM is expected to be available at RVM_HOME env var
+        WITH_OPENSSL="--with-openssl-dir=$RVM_HOME/usr"
     fi
 else
     rvm autolibs enable
-    if [[ "$detected_platform" = "darwin" ]]; then
-        WITH_OPENSSL="--with-openssl-dir=$(brew --prefix openssl@3)"
-    fi
 fi
 
 rvm get master

--- a/src/scripts/install-ruby.sh
+++ b/src/scripts/install-ruby.sh
@@ -30,6 +30,9 @@ if [[ "$RUBY_VERSION_MAJOR" -le 2 || ( "$RUBY_VERSION_MAJOR" -eq 3  &&  "$RUBY_V
     fi
 else
     rvm autolibs enable
+    if [[ "$detected_platform" = "darwin" ]]; then
+        WITH_OPENSSL="--with-openssl-dir=$(brew --prefix openssl@3)"
+    fi
 fi
 
 rvm get master


### PR DESCRIPTION
## Summary

- Bumps the `tag` parameter default in `executors/default.yml` from `2.7` to `3.3`
- Ruby 2.7 reached end-of-life in December 2023.

## Breaking change

Users who relied on the `2.7` default without pinning an explicit `tag` will now get the `cimg/ruby:3.3` image.

## Migration guide (v→v+1)

```yaml
# Pin the old version to keep it:
executor:
  name: ruby/default
  tag: "2.7"
```

Closes PIE-6